### PR TITLE
Add support for parallel execution of readonly functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog documents the changes between release versions.
 ## main
 Changes to be included in the next upcoming release
 
+- Add support for parallel execution of readonly functions ([#2](https://github.com/hasura/ndc-nodejs-lambda/pull/2))
+
 ## v0.10.0
 - Add missing query.variables capability
 

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ If functions are involved remote relationships in your Hasura metadata, then the
  * @readonly
  * @paralleldegree 5
  */
-export async function test(): Promise<string> {
-  const result = await fetch("http://httpstat.us/200")
+export async function test(statusCode: number): Promise<string> {
+  const result = await fetch("http://httpstat.us/${statusCode}")
   const responseBody = await result.json() as any;
   return responseBody.description;
 }

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -14,6 +14,7 @@
         "@tsconfig/node18": "^18.2.2",
         "commander": "^11.1.0",
         "cross-spawn": "^7.0.3",
+        "p-limit": "^3.1.0",
         "ts-api-utils": "^1.0.3",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
@@ -1612,7 +1613,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -2425,7 +2425,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -35,6 +35,7 @@
     "@tsconfig/node18": "^18.2.2",
     "commander": "^11.1.0",
     "cross-spawn": "^7.0.3",
+    "p-limit": "^3.1.0",
     "ts-api-utils": "^1.0.3",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",

--- a/ndc-lambda-sdk/src/schema.ts
+++ b/ndc-lambda-sdk/src/schema.ts
@@ -15,7 +15,8 @@ export type FunctionDefinition = {
   ndcKind: FunctionNdcKind
   description: string | null,
   arguments: ArgumentDefinition[] // Function arguments are ordered
-  resultType: TypeDefinition
+  resultType: TypeDefinition,
+  parallelDegree: number | null,
 }
 
 export enum FunctionNdcKind {

--- a/ndc-lambda-sdk/src/util.ts
+++ b/ndc-lambda-sdk/src/util.ts
@@ -29,3 +29,7 @@ export function getFlags(flagsEnum: Record<string, string | number>, value: numb
           : []
     });
 }
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}

--- a/ndc-lambda-sdk/test/execution/execute-query.test.ts
+++ b/ndc-lambda-sdk/test/execution/execute-query.test.ts
@@ -3,6 +3,7 @@ import { assert } from "chai";
 import * as sdk from "@hasura/ndc-sdk-typescript"
 import { executeQuery } from "../../src/execution";
 import { FunctionNdcKind, FunctionsSchema } from "../../src/schema";
+import { sleep } from "../../src/util";
 
 describe("execute query", function() {
   it("executes the function", async function() {
@@ -18,6 +19,7 @@ describe("execute query", function() {
         "theFunction": {
           ndcKind: FunctionNdcKind.Function,
           description: null,
+          parallelDegree: null,
           arguments: [
             {
               argumentName: "param",
@@ -80,6 +82,7 @@ describe("execute query", function() {
         "theFunction": {
           ndcKind: FunctionNdcKind.Function,
           description: null,
+          parallelDegree: null,
           arguments: [
             {
               argumentName: "param",
@@ -154,5 +157,118 @@ describe("execute query", function() {
       }
     ]);
     assert.equal(functionCallCount, 2);
-  })
+  });
+
+  it("when there are variables, executes the function in parallel, but respecting the configured parallel degree", async function() {
+    let functionCallCompletions: string[] = [];
+    const runtimeFunctions = {
+      "theFunction": async (invocationName: string, sleepMs: number) => {
+        await sleep(sleepMs);
+        functionCallCompletions.push(invocationName)
+        return invocationName;
+      }
+    };
+    const functionSchema: FunctionsSchema = {
+      functions: {
+        "theFunction": {
+          ndcKind: FunctionNdcKind.Function,
+          description: null,
+          parallelDegree: 3,
+          arguments: [
+            {
+              argumentName: "invocationName",
+              description: null,
+              type: {
+                type: "named",
+                kind: "scalar",
+                name: "String"
+              }
+            },
+            {
+              argumentName: "sleepMs",
+              description: null,
+              type: {
+                type: "named",
+                kind: "scalar",
+                name: "Float"
+              }
+            },
+          ],
+          resultType: {
+            type: "named",
+            kind: "scalar",
+            name: "String"
+          },
+        }
+      },
+      objectTypes: {},
+      scalarTypes: {
+        "String": {}
+      }
+    };
+    const queryRequest: sdk.QueryRequest = {
+      collection: "theFunction",
+      query: {
+        fields: {},
+      },
+      arguments: {
+        "invocationName": {
+          type: "variable",
+          name: "invocationName"
+        },
+        "sleepMs": {
+          type: "variable",
+          name: "sleepMs"
+        }
+      },
+      collection_relationships: {},
+      variables: [
+        {
+          "invocationName": "first",
+          "sleepMs": 100,
+        },
+        {
+          "invocationName": "second",
+          "sleepMs": 250,
+        },
+        {
+          "invocationName": "third",
+          "sleepMs": 150,
+        },
+        {
+          "invocationName": "fourth",
+          "sleepMs": 100,
+        },
+      ]
+    };
+
+    const result = await executeQuery(queryRequest, functionSchema, runtimeFunctions);
+    assert.deepStrictEqual(result, [
+      {
+        aggregates: {},
+        rows: [
+          { __value: "first" }
+        ]
+      },
+      {
+        aggregates: {},
+        rows: [
+          { __value: "second" }
+        ]
+      },
+      {
+        aggregates: {},
+        rows: [
+          { __value: "third" }
+        ]
+      },
+      {
+        aggregates: {},
+        rows: [
+          { __value: "fourth" }
+        ]
+      },
+    ]);
+    assert.deepStrictEqual(functionCallCompletions, ["first", "third", "fourth", "second"]);
+  });
 });

--- a/ndc-lambda-sdk/test/execution/prepare-arguments.test.ts
+++ b/ndc-lambda-sdk/test/execution/prepare-arguments.test.ts
@@ -9,6 +9,7 @@ describe("prepare arguments", function() {
     const functionDefinition: FunctionDefinition = {
       ndcKind: FunctionNdcKind.Function,
       description: null,
+      parallelDegree: null,
       arguments: [
         {
           argumentName: "c",
@@ -60,6 +61,7 @@ describe("prepare arguments", function() {
     const functionDefinition: FunctionDefinition = {
       ndcKind: FunctionNdcKind.Function,
       description: null,
+      parallelDegree: null,
       arguments: [
         {
           argumentName: "nullOnlyArg",
@@ -314,6 +316,7 @@ describe("prepare arguments", function() {
     const functionDefinition: FunctionDefinition = {
       ndcKind: FunctionNdcKind.Function,
       description: null,
+      parallelDegree: null,
       arguments: [
         {
           argumentName: "stringArg",
@@ -396,6 +399,7 @@ describe("prepare arguments", function() {
     const functionDefinition: FunctionDefinition = {
       ndcKind: FunctionNdcKind.Function,
       description: null,
+      parallelDegree: null,
       arguments: [
         {
           argumentName: "dateTime",
@@ -449,6 +453,7 @@ describe("prepare arguments", function() {
     const functionDefinition: FunctionDefinition = {
       ndcKind: FunctionNdcKind.Function,
       description: null,
+      parallelDegree: null,
       arguments: [
         {
           argumentName: "literalString",

--- a/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
+++ b/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
@@ -24,6 +24,7 @@ describe("basic inference", function() {
           "hello": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [],
             resultType: {
               name: "String",
@@ -34,6 +35,7 @@ describe("basic inference", function() {
           "add": {
             ndcKind: FunctionNdcKind.Function,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "a",
@@ -63,6 +65,7 @@ describe("basic inference", function() {
           "isEven": {
             ndcKind: FunctionNdcKind.Function,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "x",
@@ -83,6 +86,7 @@ describe("basic inference", function() {
           "dateTime": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [],
             resultType: {
               name: "DateTime",
@@ -93,6 +97,7 @@ describe("basic inference", function() {
           "json": {
             ndcKind: FunctionNdcKind.Function,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "input",
@@ -126,6 +131,7 @@ describe("basic inference", function() {
           "complex": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "a",
@@ -215,6 +221,7 @@ describe("basic inference", function() {
           "bar": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "string",
@@ -503,6 +510,9 @@ describe("basic inference", function() {
       functionsSchema: {
         functions: {
           "test": {
+            ndcKind: FunctionNdcKind.Procedure,
+            description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "myObject",
@@ -566,8 +576,6 @@ describe("basic inference", function() {
                 },
               },
             ],
-            description: null,
-            ndcKind: FunctionNdcKind.Procedure,
             resultType: {
               type: "nullable",
               nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
@@ -659,6 +667,7 @@ describe("basic inference", function() {
           "bar": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [],
             resultType: {
               type: "named",
@@ -717,6 +726,7 @@ describe("basic inference", function() {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
             arguments: [],
+            parallelDegree: null,
             resultType: {
               name: "LiteralProps",
               kind: "object",

--- a/ndc-lambda-sdk/test/inference/external-dependencies/external-dependencies.test.ts
+++ b/ndc-lambda-sdk/test/inference/external-dependencies/external-dependencies.test.ts
@@ -19,6 +19,7 @@ describe("external dependencies", function() {
           "useImportedPackage": {
             ndcKind: FunctionNdcKind.Function,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "s",
@@ -52,6 +53,7 @@ describe("external dependencies", function() {
           "insert_user": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "user_name",
@@ -72,6 +74,7 @@ describe("external dependencies", function() {
           "insert_todos": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "user_id",
@@ -101,6 +104,7 @@ describe("external dependencies", function() {
           "delete_todos": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "todo_id",

--- a/ndc-lambda-sdk/test/inference/naming-conflicts/naming-conflicts.test.ts
+++ b/ndc-lambda-sdk/test/inference/naming-conflicts/naming-conflicts.test.ts
@@ -15,6 +15,7 @@ describe("naming conflicts", function() {
           "foo": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [],
             resultType: {
               name: "Foo",

--- a/ndc-lambda-sdk/test/inference/parallel-degree/invalid.ts
+++ b/ndc-lambda-sdk/test/inference/parallel-degree/invalid.ts
@@ -1,0 +1,30 @@
+/**
+ * @paralleldegree 2
+ */
+export function tagUsedOnProcedure(): string {
+  return "";
+}
+
+/**
+ * @paralleldegree garbage
+ * @readonly
+ */
+export function invalidTagValue(): string {
+  return "";
+}
+
+/**
+ * @paralleldegree 0
+ * @readonly
+ */
+export function zeroParallelDegreeValue(): string {
+  return "";
+}
+
+/**
+ * @paralleldegree -1
+ * @readonly
+ */
+export function negativeDegreeValue(): string {
+  return "";
+}

--- a/ndc-lambda-sdk/test/inference/parallel-degree/parallel-degree.test.ts
+++ b/ndc-lambda-sdk/test/inference/parallel-degree/parallel-degree.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from "mocha";
+import { assert } from "chai";
+import { deriveSchema } from "../../../src/inference";
+import { BuiltInScalarTypeName, FunctionNdcKind, NullOrUndefinability } from "../../../src/schema";
+
+describe("parallel degree", function() {
+  it("reads the parallel degree from the JSDoc tag", function() {
+    const schema = deriveSchema(require.resolve("./valid.ts"));
+
+    assert.deepStrictEqual(schema, {
+      compilerDiagnostics: [],
+      functionIssues: {},
+      functionsSchema: {
+        functions: {
+          "withoutTag": {
+            ndcKind: FunctionNdcKind.Function,
+            description: null,
+            parallelDegree: null,
+            arguments: [],
+            resultType: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            }
+          },
+          "withTag": {
+            ndcKind: FunctionNdcKind.Function,
+            description: null,
+            parallelDegree: 666,
+            arguments: [],
+            resultType: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            }
+          },
+        },
+        scalarTypes: {
+          String: {},
+        },
+        objectTypes: {},
+      }
+    })
+  });
+
+  it("fails if the JSDoc tag is misused", function() {
+    const schema = deriveSchema(require.resolve("./invalid.ts"));
+
+    assert.deepStrictEqual(schema, {
+      compilerDiagnostics: [],
+      functionIssues: {
+        "tagUsedOnProcedure": [
+          "The @paralleldegree JSDoc tag is only supported on functions also marked with the @readonly JSDoc tag"
+        ],
+        "invalidTagValue": [
+          "The @paralleldegree JSDoc tag must specify an integer degree value that is greater than 0. Current value: 'garbage'"
+        ],
+        "zeroParallelDegreeValue": [
+          "The @paralleldegree JSDoc tag must specify an integer degree value that is greater than 0. Current value: '0'"
+        ],
+        "negativeDegreeValue": [
+          "The @paralleldegree JSDoc tag must specify an integer degree value that is greater than 0. Current value: '-1'"
+        ]
+      },
+      functionsSchema: {
+        functions: {},
+        scalarTypes: {
+          String: {},
+        },
+        objectTypes: {},
+      }
+    })
+  });
+});

--- a/ndc-lambda-sdk/test/inference/parallel-degree/valid.ts
+++ b/ndc-lambda-sdk/test/inference/parallel-degree/valid.ts
@@ -1,0 +1,14 @@
+/**
+ * @readonly
+ */
+export function withoutTag(): string {
+  return "";
+}
+
+/**
+ * @readonly
+ * @paralleldegree 666
+ */
+export function withTag(): string {
+  return "";
+}

--- a/ndc-lambda-sdk/test/inference/re-exported-functions/re-exported-functions.test.ts
+++ b/ndc-lambda-sdk/test/inference/re-exported-functions/re-exported-functions.test.ts
@@ -15,6 +15,7 @@ describe("re-exported functions", function() {
           "rootFileFunction": {
             ndcKind: FunctionNdcKind.Function,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "input",
@@ -35,6 +36,7 @@ describe("re-exported functions", function() {
           "fileAChildFunction": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [],
             resultType: {
               name: "String",
@@ -45,6 +47,7 @@ describe("re-exported functions", function() {
           "fileBChildFunction1": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [],
             resultType: {
               name: "Boolean",
@@ -55,6 +58,7 @@ describe("re-exported functions", function() {
           "fileBChildFunction2": {
             ndcKind: FunctionNdcKind.Function,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "input",
@@ -94,6 +98,7 @@ describe("re-exported functions", function() {
           "rootFileFunction": {
             ndcKind: FunctionNdcKind.Function,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "input",
@@ -114,6 +119,7 @@ describe("re-exported functions", function() {
           "fileAChildFunction": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [],
             resultType: {
               name: "String",
@@ -124,6 +130,7 @@ describe("re-exported functions", function() {
           "fileBChildFunction2": {
             ndcKind: FunctionNdcKind.Function,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "input",
@@ -162,6 +169,7 @@ describe("re-exported functions", function() {
           "renamedFileAChildFunction": {
             ndcKind: FunctionNdcKind.Procedure,
             description: null,
+            parallelDegree: null,
             arguments: [],
             resultType: {
               name: "String",
@@ -172,6 +180,7 @@ describe("re-exported functions", function() {
           "renamedFileBChildFunction2": {
             ndcKind: FunctionNdcKind.Function,
             description: null,
+            parallelDegree: null,
             arguments: [
               {
                 argumentName: "input",

--- a/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
+++ b/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
@@ -7,6 +7,9 @@ describe("ndc schema", function() {
     const functionsSchema: FunctionsSchema = {
       functions: {
         "test_proc": {
+          ndcKind: FunctionNdcKind.Procedure,
+          description: null,
+          parallelDegree: null,
           arguments: [
             {
               argumentName: "nullableParam",
@@ -22,8 +25,6 @@ describe("ndc schema", function() {
               },
             },
           ],
-          description: null,
-          ndcKind: FunctionNdcKind.Procedure,
           resultType: {
             type: "nullable",
             nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
@@ -35,6 +36,9 @@ describe("ndc schema", function() {
           },
         },
         "test_func": {
+          ndcKind: FunctionNdcKind.Function,
+          description: null,
+          parallelDegree: null,
           arguments: [
             {
               argumentName: "myObject",
@@ -46,8 +50,6 @@ describe("ndc schema", function() {
               },
             },
           ],
-          description: null,
-          ndcKind: FunctionNdcKind.Function,
           resultType: {
             type: "array",
             elementType: {


### PR DESCRIPTION
JIRA: [NDC-244](https://hasurahq.atlassian.net/browse/NDC-244)

This PR adds support for executing query requests with variables in a parallel fashion against the underlying function.

For more information, please see the changes to the readme.

[NDC-244]: https://hasurahq.atlassian.net/browse/NDC-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ