### PR TITLE
Add support for JSDoc descriptions from object types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ This changelog documents the changes between release versions.
 ## main
 Changes to be included in the next upcoming release
 
+- Add support for JSDoc descriptions from object types ([#3](https://github.com/hasura/ndc-nodejs-lambda/pull/3))
+
 ## v0.11.0
 - Add support for parallel execution of readonly functions ([#2](https://github.com/hasura/ndc-nodejs-lambda/pull/2))
-- Add support for JSDoc descriptions from object types ([#3](https://github.com/hasura/ndc-nodejs-lambda/pull/3))
 
 ## v0.10.0
 - Add missing query.variables capability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog documents the changes between release versions.
 Changes to be included in the next upcoming release
 
 - Add support for parallel execution of readonly functions ([#2](https://github.com/hasura/ndc-nodejs-lambda/pull/2))
+- Add support for JSDoc descriptions from object types ([#3](https://github.com/hasura/ndc-nodejs-lambda/pull/3))
 
 ## v0.10.0
 - Add missing query.variables capability

--- a/README.md
+++ b/README.md
@@ -166,6 +166,42 @@ export async function test(statusCode: number): Promise<string> {
 
 Non-readonly functions are not invoked in parallel within the same mutation request to the connector, so it is invalid to use the @paralleldegree JSDoc tag on those functions.
 
+### Documentation
+*Note: this feature is still in development.*
+
+JSDoc comments on your functions and types are used to provide descriptions for types exposed in your GraphQL schema. For example:
+
+```typescript
+/** Different types of greetings */
+interface Greeting {
+  /** A greeting if you want to be polite */
+  polite: string
+  /** A casual-toned greeting */
+  casual: string
+}
+
+/**
+ * Creates a greeting string using the specified name
+ *
+ * @param title The person's title, for example, Mr or Mrs
+ * @param firstName The person's first name
+ * @param lastName The person's last name (surname)
+ * @readonly
+ */
+export function greet(title: string, firstName: string, lastName: string): Greeting {
+  return {
+    polite: `Hello ${name.title} ${name.lastName}`,
+    casual: `G'day ${name.firstName}`
+  }
+}
+```
+
+Descriptions are collected for:
+* Functions
+* Function parameters
+* Types
+* Type properties
+
 ## Deploying with `hasura3 connector create`
 
 You will need:

--- a/ndc-lambda-sdk/src/schema.ts
+++ b/ndc-lambda-sdk/src/schema.ts
@@ -35,11 +35,13 @@ export type ObjectTypeDefinitions = {
 }
 
 export type ObjectTypeDefinition = {
+  description: string | null,
   properties: ObjectPropertyDefinition[]
 }
 
 export type ObjectPropertyDefinition = {
   propertyName: string,
+  description: string | null,
   type: TypeDefinition,
 }
 
@@ -193,7 +195,14 @@ export function getNdcSchema(functionsSchema: FunctionsSchema): sdk.SchemaRespon
 
   const objectTypes = mapObjectValues(functionsSchema.objectTypes, objDef => {
     return {
-      fields: Object.fromEntries(objDef.properties.map(propDef => [propDef.propertyName, { type: convertTypeDefinitionToSdkType(propDef.type)}]))
+      fields: Object.fromEntries(objDef.properties.map(propDef => {
+        const objField: sdk.ObjectField = {
+          type: convertTypeDefinitionToSdkType(propDef.type),
+          ...(propDef.description ? { description: propDef.description } : {})
+        }
+        return [propDef.propertyName, objField];
+      })),
+      ...(objDef.description ? { description: objDef.description } : {})
     }
   });
 

--- a/ndc-lambda-sdk/test/execution/prepare-arguments.test.ts
+++ b/ndc-lambda-sdk/test/execution/prepare-arguments.test.ts
@@ -168,9 +168,11 @@ describe("prepare arguments", function() {
     }
     const objectTypes: ObjectTypeDefinitions = {
       "MyObject": {
+        description: null,
         properties: [
           {
             propertyName: "nullOnlyProp",
+            description: null,
             type: {
               type: "nullable",
               nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
@@ -183,6 +185,7 @@ describe("prepare arguments", function() {
           },
           {
             propertyName: "undefinedOnlyProp",
+            description: null,
             type: {
               type: "nullable",
               nullOrUndefinability: NullOrUndefinability.AcceptsUndefinedOnly,
@@ -195,6 +198,7 @@ describe("prepare arguments", function() {
           },
           {
             propertyName: "nullOrUndefinedProp",
+            description: null,
             type: {
               type: "nullable",
               nullOrUndefinability: NullOrUndefinability.AcceptsEither,

--- a/ndc-lambda-sdk/test/execution/reshape-result.test.ts
+++ b/ndc-lambda-sdk/test/execution/reshape-result.test.ts
@@ -89,17 +89,21 @@ describe("reshape result", function() {
   describe("projects object types using fields", function() {
     const objectTypes: ObjectTypeDefinitions = {
       "TestObjectType": {
+        description: null,
         properties: [
           {
             propertyName: "propA",
+            description: null,
             type: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.String }
           },
           {
             propertyName: "propB",
+            description: null,
             type: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.String }
           },
           {
             propertyName: "nested",
+            description: null,
             type: { type: "nullable", nullOrUndefinability: NullOrUndefinability.AcceptsEither, underlyingType: { type: "named", kind: "object", name: "TestObjectType" } }
           }
         ]
@@ -162,13 +166,16 @@ describe("reshape result", function() {
   describe("projects object types using fields through an array type", function() {
     const objectTypes: ObjectTypeDefinitions = {
       "TestObjectType": {
+        description: null,
         properties: [
           {
             propertyName: "propA",
+            description: null,
             type: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.String }
           },
           {
             propertyName: "propB",
+            description: null,
             type: { type: "nullable", nullOrUndefinability: NullOrUndefinability.AcceptsEither, underlyingType: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.String } }
           }
         ]

--- a/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
+++ b/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
@@ -173,10 +173,12 @@ describe("basic inference", function() {
           }
         },
         objectTypes: {
-          Result: {
+          "Result": {
+            description: null,
             properties: [
               {
                 propertyName: "num",
+                description: null,
                 type: {
                   name: "Float",
                   kind: "scalar",
@@ -185,6 +187,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "str",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -193,6 +196,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "bod",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -353,9 +357,11 @@ describe("basic inference", function() {
         },
         objectTypes: {
           "GenericBar<Bar>": {
+            description: null,
             properties: [
               {
                 propertyName: "data",
+                description: null,
                 type: {
                   kind: "object",
                   name: "Bar",
@@ -365,9 +371,11 @@ describe("basic inference", function() {
             ]
           },
           "GenericBar<string>": {
+            description: null,
             properties: [
               {
                 propertyName: "data",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -377,9 +385,11 @@ describe("basic inference", function() {
             ],
           },
           "GenericIntersectionObject<string>": {
+            description: null,
             properties: [
               {
                 propertyName: "data",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -388,6 +398,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "test",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -396,10 +407,12 @@ describe("basic inference", function() {
               },
             ],
           },
-          Bar: {
+          "Bar": {
+            description: null,
             properties: [
               {
                 propertyName: "test",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -408,10 +421,12 @@ describe("basic inference", function() {
               },
             ],
           },
-          IGenericThing: {
+          "IGenericThing": {
+            description: null,
             properties: [
               {
                 propertyName: "data",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -420,10 +435,12 @@ describe("basic inference", function() {
               },
             ],
           },
-          IThing: {
+          "IThing": {
+            description: null,
             properties: [
               {
                 propertyName: "prop",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -432,10 +449,12 @@ describe("basic inference", function() {
               },
             ],
           },
-          IntersectionObject: {
+          "IntersectionObject": {
+            description: null,
             properties: [
               {
                 propertyName: "wow",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -444,6 +463,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "test",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -452,10 +472,12 @@ describe("basic inference", function() {
               },
             ],
           },
-          bar_arguments_anonIntersectionObj: {
+          "bar_arguments_anonIntersectionObj": {
+            description: null,
             properties: [
               {
                 propertyName: "num",
+                description: null,
                 type: {
                   name: "Float",
                   kind: "scalar",
@@ -464,6 +486,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "test",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -472,10 +495,12 @@ describe("basic inference", function() {
               },
             ],
           },
-          bar_arguments_anonObj: {
+          "bar_arguments_anonObj": {
+            description: null,
             properties: [
               {
                 propertyName: "a",
+                description: null,
                 type: {
                   name: "Float",
                   kind: "scalar",
@@ -484,6 +509,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "b",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -589,9 +615,11 @@ describe("basic inference", function() {
         },
         objectTypes: {
           "MyObject": {
+            description: null,
             properties: [
               {
                 propertyName: "string",
+                description: null,
                 type: {
                   kind: "scalar",
                   name: "String",
@@ -600,6 +628,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "nullableString",
+                description: null,
                 type: {
                   type: "nullable",
                   nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
@@ -612,6 +641,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "optionalString",
+                description: null,
                 type: {
                   type: "nullable",
                   nullOrUndefinability: NullOrUndefinability.AcceptsUndefinedOnly,
@@ -624,6 +654,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "undefinedString",
+                description: null,
                 type: {
                   type: "nullable",
                   nullOrUndefinability: NullOrUndefinability.AcceptsUndefinedOnly,
@@ -636,6 +667,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "nullOrUndefinedString",
+                description: null,
                 type: {
                   type: "nullable",
                   nullOrUndefinability: NullOrUndefinability.AcceptsEither,
@@ -677,10 +709,12 @@ describe("basic inference", function() {
           }
         },
         objectTypes: {
-          Foo: {
+          "Foo": {
+            description: null,
             properties: [
               {
                 propertyName: "a",
+                description: null,
                 type: {
                   type: "named",
                   kind: "scalar",
@@ -689,6 +723,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "b",
+                description: null,
                 type: {
                   type: "array",
                   elementType: {
@@ -736,9 +771,11 @@ describe("basic inference", function() {
         },
         objectTypes: {
           "LiteralProps": {
+            description: null,
             properties: [
               {
                 propertyName: "literalString",
+                description: null,
                 type: {
                   type: "named",
                   kind: "scalar",
@@ -748,6 +785,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "literalNumber",
+                description: null,
                 type: {
                   type: "named",
                   kind: "scalar",
@@ -757,6 +795,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "literalBoolean",
+                description: null,
                 type: {
                   type: "named",
                   kind: "scalar",
@@ -766,6 +805,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "literalBigInt",
+                description: null,
                 type: {
                   type: "named",
                   kind: "scalar",
@@ -775,6 +815,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "literalStringEnum",
+                description: null,
                 type: {
                   type: "named",
                   kind: "scalar",
@@ -784,6 +825,7 @@ describe("basic inference", function() {
               },
               {
                 propertyName: "literalNumericEnum",
+                description: null,
                 type: {
                   type: "named",
                   kind: "scalar",

--- a/ndc-lambda-sdk/test/inference/external-dependencies/external-dependencies.test.ts
+++ b/ndc-lambda-sdk/test/inference/external-dependencies/external-dependencies.test.ts
@@ -129,9 +129,11 @@ describe("external dependencies", function() {
         },
         objectTypes: {
           "delete_todos_output": {
+            description: null,
             properties: [
               {
                 propertyName: "error",
+                description: null,
                 type: {
                   nullOrUndefinability: NullOrUndefinability.AcceptsUndefinedOnly,
                   type: "nullable",
@@ -144,6 +146,7 @@ describe("external dependencies", function() {
               },
               {
                 propertyName: "result",
+                description: null,
                 type: {
                   nullOrUndefinability: NullOrUndefinability.AcceptsUndefinedOnly,
                   type: "nullable",

--- a/ndc-lambda-sdk/test/inference/naming-conflicts/naming-conflicts.test.ts
+++ b/ndc-lambda-sdk/test/inference/naming-conflicts/naming-conflicts.test.ts
@@ -25,10 +25,12 @@ describe("naming conflicts", function() {
           }
         },
         objectTypes: {
-          Foo: {
+          "Foo": {
+            description: null,
             properties: [
               {
                 propertyName: "x",
+                description: null,
                 type: {
                   name: "Boolean",
                   kind: "scalar",
@@ -37,6 +39,7 @@ describe("naming conflicts", function() {
               },
               {
                 propertyName: "y",
+                description: null,
                 type: {
                   name: "conflict_from_import_dep_Foo",
                   kind: "object",
@@ -45,10 +48,12 @@ describe("naming conflicts", function() {
               },
             ]
           },
-          conflict_from_import_dep_Foo: {
+          "conflict_from_import_dep_Foo": {
+            description: null,
             properties: [
               {
                 propertyName: "a",
+                description: null,
                 type: {
                   name: "String",
                   kind: "scalar",
@@ -57,6 +62,7 @@ describe("naming conflicts", function() {
               },
               {
                 propertyName: "b",
+                description: null,
                 type: {
                   name: "Float",
                   kind: "scalar",

--- a/ndc-lambda-sdk/test/inference/type-descriptions/functions.ts
+++ b/ndc-lambda-sdk/test/inference/type-descriptions/functions.ts
@@ -1,0 +1,12 @@
+/**
+ * My cool function. It's a great function.
+ * You should totally use it.
+ *
+ * @param amaze This is a great and amazing param.
+ * Definitely pass something for it.
+ *
+ * @readonly
+ */
+export function myFunction(amaze: string): string {
+  return "";
+}

--- a/ndc-lambda-sdk/test/inference/type-descriptions/object-types.ts
+++ b/ndc-lambda-sdk/test/inference/type-descriptions/object-types.ts
@@ -1,0 +1,42 @@
+/**
+ * My object type is the best object type.
+ * You should make all object types like mine.
+ */
+type MyObjType = {
+  /** This is a good property */
+  propA: string
+}
+
+/**
+ * What a great interface
+ */
+interface IInterface {
+  /** The best of all properties */
+  prop: string
+}
+
+/**
+ * The most generic of interfaces
+ */
+interface IGenericInterface<T> {
+  /** Whatever you'd like it to be */
+  whatever: T
+}
+
+/**
+ * Just smashing things together over here
+ */
+type IntersectionType = MyObjType & {
+  /** I'm just adding another prop here */
+  anotherProp: string
+}
+
+/** @readonly */
+export function myFunction(
+  myObjType: MyObjType,
+  iface: IInterface,
+  genericInterface: IGenericInterface<string>,
+  intersectionType: IntersectionType
+  ): string {
+  return ""
+}

--- a/ndc-lambda-sdk/test/inference/type-descriptions/type-descriptions.test.ts
+++ b/ndc-lambda-sdk/test/inference/type-descriptions/type-descriptions.test.ts
@@ -1,0 +1,175 @@
+import { describe, it } from "mocha";
+import { assert } from "chai";
+import { deriveSchema } from "../../../src/inference";
+import { BuiltInScalarTypeName, FunctionNdcKind, NullOrUndefinability } from "../../../src/schema";
+
+describe("type descriptions", function() {
+  it("descriptions are derived for function and function arguments", function() {
+    const schema = deriveSchema(require.resolve("./functions.ts"));
+
+    assert.deepStrictEqual(schema, {
+      compilerDiagnostics: [],
+      functionIssues: {},
+      functionsSchema: {
+        functions: {
+          "myFunction": {
+            ndcKind: FunctionNdcKind.Function,
+            description: "My cool function. It's a great function.\nYou should totally use it.",
+            parallelDegree: null,
+            arguments: [
+              {
+                argumentName: "amaze",
+                description: "This is a great and amazing param.\nDefinitely pass something for it.",
+                type: {
+                  name: "String",
+                  kind: "scalar",
+                  type: "named",
+                }
+              },
+            ],
+            resultType: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            }
+          },
+        },
+        scalarTypes: {
+          String: {},
+        },
+        objectTypes: {},
+      }
+    })
+  });
+
+  it("descriptions are derived for object types and their properties", function() {
+    const schema = deriveSchema(require.resolve("./object-types.ts"));
+
+    assert.deepStrictEqual(schema, {
+      compilerDiagnostics: [],
+      functionIssues: {},
+      functionsSchema: {
+        functions: {
+          "myFunction": {
+            ndcKind: FunctionNdcKind.Function,
+            description: null,
+            parallelDegree: null,
+            arguments: [
+              {
+                argumentName: "myObjType",
+                description: null,
+                type: {
+                  name: "MyObjType",
+                  kind: "object",
+                  type: "named",
+                }
+              },
+              {
+                argumentName: "iface",
+                description: null,
+                type: {
+                  name: "IInterface",
+                  kind: "object",
+                  type: "named",
+                }
+              },
+              {
+                argumentName: "genericInterface",
+                description: null,
+                type: {
+                  name: "IGenericInterface",
+                  kind: "object",
+                  type: "named",
+                }
+              },
+              {
+                argumentName: "intersectionType",
+                description: null,
+                type: {
+                  name: "IntersectionType",
+                  kind: "object",
+                  type: "named",
+                }
+              },
+            ],
+            resultType: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            }
+          },
+        },
+        scalarTypes: {
+          String: {},
+        },
+        objectTypes: {
+          "MyObjType": {
+            description: "My object type is the best object type.\nYou should make all object types like mine.",
+            properties: [
+              {
+                propertyName: "propA",
+                description: "This is a good property",
+                type: {
+                  type: "named",
+                  kind: "scalar",
+                  name: "String"
+                }
+              }
+            ]
+          },
+          "IInterface": {
+            description: "What a great interface",
+            properties: [
+              {
+                propertyName: "prop",
+                description: "The best of all properties",
+                type: {
+                  type: "named",
+                  kind: "scalar",
+                  name: "String"
+                }
+              }
+            ]
+          },
+          "IGenericInterface": {
+            description: "The most generic of interfaces",
+            properties: [
+              {
+                propertyName: "whatever",
+                description: "Whatever you'd like it to be",
+                type: {
+                  type: "named",
+                  kind: "scalar",
+                  name: "String"
+                }
+              }
+            ]
+          },
+          "IntersectionType": {
+            description: "Just smashing things together over here",
+            properties: [
+              {
+                propertyName: "propA",
+                description: "This is a good property",
+                type: {
+                  type: "named",
+                  kind: "scalar",
+                  name: "String"
+                }
+              },
+              {
+                propertyName: "anotherProp",
+                description: "I'm just adding another prop here",
+                type: {
+                  type: "named",
+                  kind: "scalar",
+                  name: "String"
+                }
+              }
+            ]
+          }
+        },
+      }
+    })
+  });
+});

--- a/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
+++ b/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
@@ -8,12 +8,12 @@ describe("ndc schema", function() {
       functions: {
         "test_proc": {
           ndcKind: FunctionNdcKind.Procedure,
-          description: null,
+          description: "My procedure",
           parallelDegree: null,
           arguments: [
             {
               argumentName: "nullableParam",
-              description: null,
+              description: "A nullable param",
               type: {
                 type: "nullable",
                 nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
@@ -37,12 +37,12 @@ describe("ndc schema", function() {
         },
         "test_func": {
           ndcKind: FunctionNdcKind.Function,
-          description: null,
+          description: "My function",
           parallelDegree: null,
           arguments: [
             {
               argumentName: "myObject",
-              description: null,
+              description: "My object param",
               type: {
                 kind: "object",
                 name: "MyObject",
@@ -62,9 +62,11 @@ describe("ndc schema", function() {
       },
       objectTypes: {
         "MyObject": {
+          description: "My Object Type",
           properties: [
             {
               propertyName: "string",
+              description: "A string",
               type: {
                 kind: "scalar",
                 name: "String",
@@ -73,6 +75,7 @@ describe("ndc schema", function() {
             },
             {
               propertyName: "nullableString",
+              description: "A nullable string",
               type: {
                 type: "nullable",
                 nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
@@ -99,8 +102,10 @@ describe("ndc schema", function() {
       functions: [
         {
           name: "test_func",
+          description: "My function",
           arguments: {
             "myObject": {
+              description: "My object param",
               type: {
                 name: "MyObject",
                 type: "named",
@@ -119,8 +124,10 @@ describe("ndc schema", function() {
       procedures: [
         {
           name: "test_proc",
+          description: "My procedure",
           arguments: {
             "nullableParam": {
+              description: "A nullable param",
               type: {
                 type: "nullable",
                 underlying_type: {
@@ -141,14 +148,17 @@ describe("ndc schema", function() {
       ],
       object_types: {
         "MyObject": {
+          description: "My Object Type",
           fields: {
             "string": {
+              description: "A string",
               type: {
                 name: "String",
                 type: "named",
               },
             },
             "nullableString": {
+              description: "A nullable string",
               type: {
                 type: "nullable",
                 underlying_type: {


### PR DESCRIPTION
~~Note: This PR is stacked on #2 and will be rebased on main when that PR merges.~~ Done.

JIRA: [NDC-345](https://hasurahq.atlassian.net/browse/NDC-345)

This PR adds support for JSDoc descriptions on object types. We currently support picking up descriptions from function definitions and function arguments, but object types and their properties were missed.

For example, we now support:
```
/**
 * My object type is the best object type.
 * You should make all object types like mine.
 */
type MyObjType = {
  /** This is a good property */
  propA: string
}
```

Unit tests have been added to check gathering of descriptions from functions and from types.

[NDC-345]: https://hasurahq.atlassian.net/browse/NDC-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ