### PR TITLE
Fix type name conflicts when using generic interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog documents the changes between release versions.
 Changes to be included in the next upcoming release
 
 - Add support for JSDoc descriptions from object types ([#3](https://github.com/hasura/ndc-nodejs-lambda/pull/3))
+- Fix type name conflicts when using generic interfaces ([#4](https://github.com/hasura/ndc-nodejs-lambda/pull/4))
 
 ## v0.11.0
 - Add support for parallel execution of readonly functions ([#2](https://github.com/hasura/ndc-nodejs-lambda/pull/2))

--- a/ndc-lambda-sdk/src/inference.ts
+++ b/ndc-lambda-sdk/src/inference.ts
@@ -518,18 +518,21 @@ function getObjectTypeInfo(tsType: ts.Type, typePath: TypePathSegment[], typeChe
   }
   // Interface type - this covers:
   // interface IThing { test: string }
+  // type AliasedIThing = IThing (the alias is erased by the compiler)
   else if (tsutils.isObjectType(tsType) && tsutils.isObjectFlagSet(tsType, ts.ObjectFlags.Interface)) {
     return {
-      generatedTypeName: tsType.getSymbol()?.name ?? generateTypeNameFromTypePath(typePath),
+      generatedTypeName: typeChecker.typeToString(tsType),
       properties: getMembers(tsType.getProperties(), typeChecker),
       description,
     }
   }
   // Generic interface type - this covers:
   // interface IGenericThing<T> { data: T }
+  // type AliasedIGenericThing<T> = IGenericThing<T>
+  // type AliasedClosedIGenericThing = IGenericThing<string>
   else if (tsutils.isTypeReference(tsType) && tsutils.isObjectFlagSet(tsType.target, ts.ObjectFlags.Interface) && typeChecker.isArrayType(tsType) === false && tsType.getSymbol()?.getName() !== "Promise") {
     return {
-      generatedTypeName: tsType.getSymbol()?.name ?? generateTypeNameFromTypePath(typePath),
+      generatedTypeName: typeChecker.typeToString(tsType),
       properties: getMembers(tsType.getProperties(), typeChecker),
       description,
     }

--- a/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
+++ b/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
@@ -312,12 +312,39 @@ describe("basic inference", function() {
                 }
               },
               {
+                argumentName: "aliasedInterface",
+                description: null,
+                type: {
+                  type: "named",
+                  kind: "object",
+                  name: "IThing"
+                }
+              },
+              {
                 argumentName: "genericInterface",
                 description: null,
                 type: {
                   type: "named",
                   kind: "object",
-                  name: "IGenericThing"
+                  name: "IGenericThing<string>"
+                }
+              },
+              {
+                argumentName: "aliasedGenericInterface",
+                description: null,
+                type: {
+                  type: "named",
+                  kind: "object",
+                  name: "AliasedIGenericThing<number>"
+                }
+              },
+              {
+                argumentName: "aliasedClosedInterface",
+                description: null,
+                type: {
+                  type: "named",
+                  kind: "object",
+                  name: "AliasedClosedIGenericThing"
                 }
               },
               {
@@ -421,7 +448,7 @@ describe("basic inference", function() {
               },
             ],
           },
-          "IGenericThing": {
+          "IGenericThing<string>": {
             description: null,
             properties: [
               {
@@ -429,6 +456,34 @@ describe("basic inference", function() {
                 description: null,
                 type: {
                   name: "String",
+                  kind: "scalar",
+                  type: "named",
+                },
+              },
+            ],
+          },
+          "AliasedIGenericThing<number>": {
+            description: null,
+            properties: [
+              {
+                propertyName: "data",
+                description: null,
+                type: {
+                  name: "Float",
+                  kind: "scalar",
+                  type: "named",
+                },
+              },
+            ],
+          },
+          "AliasedClosedIGenericThing": {
+            description: null,
+            properties: [
+              {
+                propertyName: "data",
+                description: null,
+                type: {
+                  name: "Float",
                   kind: "scalar",
                   type: "named",
                 },

--- a/ndc-lambda-sdk/test/inference/basic-inference/complex-types.ts
+++ b/ndc-lambda-sdk/test/inference/basic-inference/complex-types.ts
@@ -10,16 +10,25 @@ interface IThing {
   prop: string
 }
 
+// This alias just gets erased by the TS compiler
+type AliasedIThing = IThing;
+
 interface IGenericThing<T> {
   data: T
 }
+
+type AliasedIGenericThing<T> = IGenericThing<T>
+
+type AliasedClosedIGenericThing = IGenericThing<number>
 
 type IntersectionObject = { wow: string } & Bar
 
 type GenericIntersectionObject<T> = { data: T } & Bar
 
+// This alias just gets erased by the TS compiler
 type AliasedString = string;
 
+// These aliases just get erased by the TS compiler
 type GenericScalar<T> = GenericScalar2<T>
 type GenericScalar2<T> = T
 
@@ -33,7 +42,10 @@ export function bar(
   genericAliasedObj: GenericBar<string>,
   genericAliasedObjWithComplexTypeParam: GenericBar<Bar>,
   interfce: IThing,
+  aliasedInterface: AliasedIThing,
   genericInterface: IGenericThing<string>,
+  aliasedGenericInterface: AliasedIGenericThing<number>,
+  aliasedClosedInterface: AliasedClosedIGenericThing,
   aliasedIntersectionObj: IntersectionObject,
   anonIntersectionObj: {num:number} & Bar,
   genericIntersectionObj: GenericIntersectionObject<string>,

--- a/ndc-lambda-sdk/test/inference/type-descriptions/type-descriptions.test.ts
+++ b/ndc-lambda-sdk/test/inference/type-descriptions/type-descriptions.test.ts
@@ -77,7 +77,7 @@ describe("type descriptions", function() {
                 argumentName: "genericInterface",
                 description: null,
                 type: {
-                  name: "IGenericInterface",
+                  name: "IGenericInterface<string>",
                   kind: "object",
                   type: "named",
                 }
@@ -131,7 +131,7 @@ describe("type descriptions", function() {
               }
             ]
           },
-          "IGenericInterface": {
+          "IGenericInterface<string>": {
             description: "The most generic of interfaces",
             properties: [
               {


### PR DESCRIPTION
~~This PR is currently stacked on #3 and will be rebased on main when that PR merges.~~ Done

JIRA: [NDC-346](https://hasurahq.atlassian.net/browse/NDC-346)

When using the same generic interface with different types (eg `IGeneric<string>` and `IGeneric<number>`) a conflicting type name would be used (`IGeneric`) that would cause the wrong type to be used.

This has been fixed so that the generic type parameters are retained in the type name to ensure each instantiation of the generic type has its own NDC type.

[NDC-346]: https://hasurahq.atlassian.net/browse/NDC-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ