### PR TITLE
Improve error handling of errors thrown from functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changes to be included in the next upcoming release
 
 - Add support for JSDoc descriptions from object types ([#3](https://github.com/hasura/ndc-nodejs-lambda/pull/3))
 - Fix type name conflicts when using generic interfaces ([#4](https://github.com/hasura/ndc-nodejs-lambda/pull/4))
+- Improve error handling of errors thrown from functions ([#5](https://github.com/hasura/ndc-nodejs-lambda/pull/5))
+  - The entire causal stack trace is now captured as an error detail for unhandled errors
+  - `sdk.Forbidden`, `sdk.Conflict`, `sdk.UnprocessableContent` can be thrown to return error details to GraphQL API clients
 
 ## v0.11.0
 - Add support for parallel execution of readonly functions ([#2](https://github.com/hasura/ndc-nodejs-lambda/pull/2))

--- a/ndc-lambda-sdk/.mocharc.json
+++ b/ndc-lambda-sdk/.mocharc.json
@@ -1,5 +1,5 @@
 {
-  "require": "ts-node/register",
+  "require": ["ts-node/register", "test/init.ts"],
   "extensions": ["ts", "tsx"],
   "spec": [
     "test/**/*.test.ts"

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -25,8 +25,10 @@
       },
       "devDependencies": {
         "@types/chai": "^4.3.11",
+        "@types/chai-as-promised": "^7.1.8",
         "@types/mocha": "^10.0.6",
         "chai": "^4.3.7",
+        "chai-as-promised": "^7.1.1",
         "mocha": "^10.2.0",
         "node-emoji": "^2.1.3",
         "node-postgres": "^0.6.2"
@@ -349,6 +351,15 @@
       "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
       "dev": true
     },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.8",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz",
+      "integrity": "sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
@@ -641,6 +652,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chalk": {

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -43,8 +43,10 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",
+    "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": "^10.0.6",
     "chai": "^4.3.7",
+    "chai-as-promised": "^7.1.1",
     "mocha": "^10.2.0",
     "node-emoji": "^2.1.3",
     "node-postgres": "^0.6.2"

--- a/ndc-lambda-sdk/src/execution.ts
+++ b/ndc-lambda-sdk/src/execution.ts
@@ -183,18 +183,27 @@ export function getErrorDetails(error: Error): ErrorDetails {
 }
 
 function buildCausalStackTrace(error: Error): string {
+  let seenErrs: Error[] = [];
   let currErr: Error | undefined = error;
   let stackTrace = "";
 
   while (currErr) {
+    seenErrs.push(currErr);
+
     if (currErr.stack) {
       stackTrace += `${currErr.stack}${EOL}`;
     } else {
       stackTrace += `${currErr.toString()}${EOL}`;
     }
     if (currErr.cause instanceof Error) {
-      stackTrace += `caused by `;
-      currErr = currErr.cause;
+      if (seenErrs.includes(currErr.cause)) {
+        stackTrace += "<circular error cause loop>"
+        currErr = undefined;
+      } else {
+        stackTrace += `caused by `;
+        currErr = currErr.cause;
+      }
+
     } else {
       currErr = undefined;
     }

--- a/ndc-lambda-sdk/src/sdk.ts
+++ b/ndc-lambda-sdk/src/sdk.ts
@@ -1,3 +1,3 @@
-import { JSONValue } from "./schema";
-
-export { JSONValue };
+export { JSONValue } from "./schema";
+export { ConnectorError, BadRequest, Forbidden, Conflict, UnprocessableContent, InternalServerError, NotSupported, BadGateway } from "@hasura/ndc-sdk-typescript";
+export { ErrorDetails, getErrorDetails } from "./execution";

--- a/ndc-lambda-sdk/test/init.ts
+++ b/ndc-lambda-sdk/test/init.ts
@@ -1,0 +1,8 @@
+// This file is hooked into mocha via .mocharc.json
+
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised"
+
+export const mochaGlobalSetup = function() {
+  chai.use(chaiAsPromised);
+};


### PR DESCRIPTION
This PR improves the error handling of errors thrown from functions. 

JIRA: [NDC-255](https://hasurahq.atlassian.net/browse/NDC-255)
GitHub: Fixes #1

Unknown Error types now have their entire causal stack trace recorded in the InternalServerError's details (previously it was only the immediate Error's stack trace).

Also, NDC TypeScript SDK error classes are now passed through transparently, and have been re-exported from the Lambda SDK. This allows function authors to throw `sdk.Forbidden`, `sdk.Conflict`, `sdk.UnprocessableContent` to return error details to GraphQL API clients.

For more details and examples, see the readme changes.

[NDC-255]: https://hasurahq.atlassian.net/browse/NDC-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ