### PR TITLE
Add support for treating 'true | false' as a Boolean type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog documents the changes between release versions.
 ## main
 Changes to be included in the next upcoming release
 
+- Add support for treating 'true | false' as a Boolean type ([#7](https://github.com/hasura/ndc-nodejs-lambda/pull/7))
+
 ## v0.12.0
 - Add support for JSDoc descriptions from object types ([#3](https://github.com/hasura/ndc-nodejs-lambda/pull/3))
 - Fix type name conflicts when using generic interfaces ([#4](https://github.com/hasura/ndc-nodejs-lambda/pull/4))

--- a/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
+++ b/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
@@ -255,6 +255,15 @@ describe("basic inference", function() {
                 }
               },
               {
+                argumentName: "booleanUnion",
+                description: null,
+                type: {
+                  type: "named",
+                  kind: "scalar",
+                  name: "Boolean"
+                }
+              },
+              {
                 argumentName: "array",
                 description: null,
                 type: {
@@ -575,6 +584,7 @@ describe("basic inference", function() {
           },
         },
         scalarTypes: {
+          Boolean: {},
           Float: {},
           String: {},
         }
@@ -708,6 +718,19 @@ describe("basic inference", function() {
                 },
               },
               {
+                propertyName: "optionalBoolean",
+                description: null,
+                type: {
+                  type: "nullable",
+                  nullOrUndefinability: NullOrUndefinability.AcceptsUndefinedOnly,
+                  underlyingType: {
+                    kind: "scalar",
+                    name: "Boolean",
+                    type: "named",
+                  },
+                },
+              },
+              {
                 propertyName: "undefinedString",
                 description: null,
                 type: {
@@ -737,6 +760,7 @@ describe("basic inference", function() {
           },
         },
         scalarTypes: {
+          Boolean: {},
           String: {},
         },
       }

--- a/ndc-lambda-sdk/test/inference/basic-inference/complex-types.ts
+++ b/ndc-lambda-sdk/test/inference/basic-inference/complex-types.ts
@@ -36,6 +36,7 @@ export function bar(
   string: string,
   aliasedString: AliasedString,
   genericScalar: GenericScalar<string>,
+  booleanUnion: true | false,
   array: string[],
   anonObj: {a: number, b: string},
   aliasedObj: Bar,

--- a/ndc-lambda-sdk/test/inference/basic-inference/nullable-types.ts
+++ b/ndc-lambda-sdk/test/inference/basic-inference/nullable-types.ts
@@ -2,6 +2,7 @@ type MyObject = {
   string: string,
   nullableString: string | null,
   optionalString?: string
+  optionalBoolean?: boolean
   undefinedString: string | undefined
   nullOrUndefinedString: string | undefined | null
 }


### PR DESCRIPTION
This PR adds support for treating the `true | false` type as a Boolean type. 

This rears its head in unexpected corner cases with nullable/undefined boolean properties. The TypeScript compiler will express the type of `boolean | undefined` (or `property?: boolean`) as `undefined | true | false`, which is weird. Some special code has been added to the place where we unwrap null or undefined from union types which detects this and converts the `true | false` into a `boolean` type. This ensure we can handle null or undefined boolean types properly.

JIRA: [NDC-387](https://hasurahq.atlassian.net/browse/NDC-387)

[NDC-387]: https://hasurahq.atlassian.net/browse/NDC-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ