### PR TITLE
Support for NDC Spec v0.1.0-rc.15 and nested object/array selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ This changelog documents the changes between release versions.
 ## main
 Changes to be included in the next upcoming release
 
-- Support for NDC Spec v0.1.0-rc.14 via the NDC TypeScript SDK v2.0.0. This is a breaking change and must be used with the latest Hasura engine.
+- Support for NDC Spec v0.1.0-rc.15 via the NDC TypeScript SDK v3.0.0. This is a breaking change and must be used with the latest Hasura engine.
   - Support for nested object/array selection
   - New function calling convention that relies on nested object queries
+  - New mutation request/response format
 
 ## v0.13.0
 - Add support for treating 'true | false' as a Boolean type ([#7](https://github.com/hasura/ndc-nodejs-lambda/pull/7))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog documents the changes between release versions.
 ## main
 Changes to be included in the next upcoming release
 
+- Support for NDC Spec v0.1.0-rc.14 via the NDC TypeScript SDK v2.0.0. This is a breaking change and must be used with the latest Hasura engine.
+  - Support for nested object/array selection
+  - New function calling convention that relies on nested object queries
+
 ## v0.13.0
 - Add support for treating 'true | false' as a Boolean type ([#7](https://github.com/hasura/ndc-nodejs-lambda/pull/7))
 

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hasura/ndc-sdk-typescript": "^1.2.8",
+        "@hasura/ndc-sdk-typescript": "^2.0.0",
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@tsconfig/node18": "^18.2.2",
         "commander": "^11.1.0",
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@hasura/ndc-sdk-typescript": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-1.2.8.tgz",
-      "integrity": "sha512-nmQXRbo8dAcdtdmE0pO5J7Ofka0M3QiwtAtAD4JCo0n/nJWUn1tFZy9BIRguYUQW7EOnYk83DxcVm1/sySDn4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-2.0.0.tgz",
+      "integrity": "sha512-GWesuB0SyOjlxBoGQUuB6aDha5y7CSrgGpCs6JH/mRdOst+LMVvSPYeq9SDS8FTsdi2dMQpL1tzvpLnFei+UXg==",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@types/node": "^20.6.0",

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hasura/ndc-sdk-typescript": "^2.0.0",
+        "@hasura/ndc-sdk-typescript": "^3.0.0",
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@tsconfig/node18": "^18.2.2",
         "commander": "^11.1.0",
@@ -74,12 +74,11 @@
       }
     },
     "node_modules/@hasura/ndc-sdk-typescript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-2.0.0.tgz",
-      "integrity": "sha512-GWesuB0SyOjlxBoGQUuB6aDha5y7CSrgGpCs6JH/mRdOst+LMVvSPYeq9SDS8FTsdi2dMQpL1tzvpLnFei+UXg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-3.0.0.tgz",
+      "integrity": "sha512-Y4CuobtWdWSh5CCetyPzflyo1vISmZJenZ6DELRTlHHt+wwr2lCCKXb2rGRg7rbDglzG3KE2LnoER16LuGnoiw==",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
-        "@types/node": "^20.6.0",
         "commander": "^11.0.0",
         "fastify": "^4.23.2",
         "pino-pretty": "^10.2.3"
@@ -370,6 +369,7 @@
       "version": "20.10.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
       "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2306,7 +2306,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "peer": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -30,7 +30,7 @@
     "url": "git+https://github.com/hasura/ndc-nodejs-lambda.git"
   },
   "dependencies": {
-    "@hasura/ndc-sdk-typescript": "^2.0.0",
+    "@hasura/ndc-sdk-typescript": "^3.0.0",
     "@json-schema-tools/meta-schema": "^1.7.0",
     "@tsconfig/node18": "^18.2.2",
     "commander": "^11.1.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -30,7 +30,7 @@
     "url": "git+https://github.com/hasura/ndc-nodejs-lambda.git"
   },
   "dependencies": {
-    "@hasura/ndc-sdk-typescript": "^1.2.8",
+    "@hasura/ndc-sdk-typescript": "^2.0.0",
     "@json-schema-tools/meta-schema": "^1.7.0",
     "@tsconfig/node18": "^18.2.2",
     "commander": "^11.1.0",

--- a/ndc-lambda-sdk/src/cmdline.ts
+++ b/ndc-lambda-sdk/src/cmdline.ts
@@ -17,13 +17,13 @@ export function makeCommand(commandActions: CommandActions): Command {
     .name("ndc-lambda-sdk")
     .version(version);
 
-  const serveCommand = sdk.get_serve_command();
+  const serveCommand = sdk.getServeCommand();
   serveCommand.action((serverOptions: sdk.ServerOptions, command: Command) => {
     const hostOpts: HostOptions = hostCommand.opts();
     return commandActions.serveAction(hostOpts, serverOptions);
   })
 
-  const configurationServeCommand = sdk.get_serve_configuration_command();
+  const configurationServeCommand = sdk.getServeConfigurationCommand();
   configurationServeCommand.commands.find(c => c.name() === "serve")?.action((serverOptions: sdk.ConfigurationServerOptions, command: Command) => {
     const hostOpts: HostOptions = hostCommand.opts();
     return commandActions.configurationServeAction(hostOpts, serverOptions);

--- a/ndc-lambda-sdk/src/connector.ts
+++ b/ndc-lambda-sdk/src/connector.ts
@@ -15,7 +15,7 @@ export type State = {
 }
 
 export const RAW_CONFIGURATION_SCHEMA: JSONSchemaObject = {
-  description: 'NodeJS Functions SDK Connector Configuration',
+  description: 'NodeJS Lambda SDK Connector Configuration',
   type: 'object',
   required: [],
   properties: {}

--- a/ndc-lambda-sdk/src/connector.ts
+++ b/ndc-lambda-sdk/src/connector.ts
@@ -29,19 +29,19 @@ export function createConnector(options: ConnectorOptions): sdk.Connector<RawCon
   const functionsFilePath = path.resolve(options.functionsFilePath);
 
   const connector: sdk.Connector<RawConfiguration, Configuration, State> = {
-    get_raw_configuration_schema: function (): JSONSchemaObject {
+    getRawConfigurationSchema: function (): JSONSchemaObject {
       return RAW_CONFIGURATION_SCHEMA;
     },
 
-    make_empty_configuration: function (): RawConfiguration {
+    makeEmptyConfiguration: function (): RawConfiguration {
       return {};
     },
 
-    update_configuration: async function (rawConfiguration: RawConfiguration): Promise<RawConfiguration> {
+    updateConfiguration: async function (rawConfiguration: RawConfiguration): Promise<RawConfiguration> {
       return {};
     },
 
-    validate_raw_configuration: async function (rawConfiguration: RawConfiguration): Promise<Configuration> {
+    validateRawConfiguration: async function (rawConfiguration: RawConfiguration): Promise<Configuration> {
       const schemaResults = deriveSchema(functionsFilePath);
       printCompilerDiagnostics(schemaResults.compilerDiagnostics);
       printFunctionIssues(schemaResults.functionIssues);
@@ -50,7 +50,7 @@ export function createConnector(options: ConnectorOptions): sdk.Connector<RawCon
       }
     },
 
-    try_init_state: async function (configuration: Configuration, metrics: unknown): Promise<State> {
+    tryInitState: async function (configuration: Configuration, metrics: unknown): Promise<State> {
       if (Object.keys(configuration.functionsSchema.functions).length === 0) {
         // If there are no declared functions, don't bother trying to load the code.
         // There's very likely to be compiler errors during schema inference that will
@@ -60,18 +60,19 @@ export function createConnector(options: ConnectorOptions): sdk.Connector<RawCon
       return { runtimeFunctions: require(functionsFilePath) }
     },
 
-    get_capabilities: function (configuration: Configuration): sdk.CapabilitiesResponse {
+    getCapabilities: function (configuration: Configuration): sdk.CapabilitiesResponse {
       return {
-        versions: "^0.1.0",
+        version: "0.1.0",
         capabilities: {
           query: {
             variables: {}
           },
+          mutation: {},
         }
       };
     },
 
-    get_schema: async function (configuration: Configuration): Promise<sdk.SchemaResponse> {
+    getSchema: async function (configuration: Configuration): Promise<sdk.SchemaResponse> {
       return getNdcSchema(configuration.functionsSchema);
     },
 
@@ -83,15 +84,19 @@ export function createConnector(options: ConnectorOptions): sdk.Connector<RawCon
       return await executeMutation(request, configuration.functionsSchema, state.runtimeFunctions);
     },
 
-    explain: function (configuration: Configuration, state: State, request: sdk.QueryRequest): Promise<sdk.ExplainResponse> {
+    queryExplain: function (configuration: Configuration, state: State, request: sdk.QueryRequest): Promise<sdk.ExplainResponse> {
       throw new Error("Function not implemented.");
     },
 
-    health_check: async function (configuration: Configuration, state: State): Promise<undefined> {
+    mutationExplain: function (configuration: Configuration, state: State, request: sdk.MutationRequest): Promise<sdk.ExplainResponse> {
+      throw new Error("Function not implemented.");
+    },
+
+    healthCheck: async function (configuration: Configuration, state: State): Promise<undefined> {
       return undefined;
     },
 
-    fetch_metrics: async function (configuration: Configuration, state: State): Promise<undefined> {
+    fetchMetrics: async function (configuration: Configuration, state: State): Promise<undefined> {
       return undefined;
     },
   }

--- a/ndc-lambda-sdk/src/execution.ts
+++ b/ndc-lambda-sdk/src/execution.ts
@@ -41,15 +41,16 @@ export async function executeQuery(queryRequest: sdk.QueryRequest, functionsSche
 }
 
 export async function executeMutation(mutationRequest: sdk.MutationRequest, functionsSchema: schema.FunctionsSchema, runtimeFunctions: RuntimeFunctions): Promise<sdk.MutationResponse> {
-  const operationResults: sdk.MutationOperationResults[] = [];
+  if (mutationRequest.operations.length > 1)
+    throw new sdk.NotSupported("Transactional mutations (multiple operations) are not supported");
+  if (mutationRequest.operations.length <= 0)
+    throw new sdk.BadRequest("One mutation operation must be provided")
 
-  for (const mutationOperation of mutationRequest.operations) {
-    const result = await executeMutationOperation(mutationOperation, functionsSchema, runtimeFunctions);
-    operationResults.push(result);
-  }
+  const mutationOperation = mutationRequest.operations[0]!;
+  const result = await executeMutationOperation(mutationOperation, functionsSchema, runtimeFunctions);
 
   return {
-    operation_results: operationResults
+    operation_results: [result]
   };
 }
 

--- a/ndc-lambda-sdk/src/host.ts
+++ b/ndc-lambda-sdk/src/host.ts
@@ -3,8 +3,8 @@ import { createConnector } from "./connector";
 import { makeCommand } from "./cmdline";
 
 const program = makeCommand({
-  serveAction: (hostOpts, serveOpts) => sdk.start_server(createConnector({functionsFilePath: hostOpts.functions}), serveOpts),
-  configurationServeAction: (hostOpts, serveOpts) => sdk.start_configuration_server(createConnector({functionsFilePath: hostOpts.functions}), serveOpts),
+  serveAction: (hostOpts, serveOpts) => sdk.startServer(createConnector({functionsFilePath: hostOpts.functions}), serveOpts),
+  configurationServeAction: (hostOpts, serveOpts) => sdk.startConfigurationServer(createConnector({functionsFilePath: hostOpts.functions}), serveOpts),
 });
 
 program.parseAsync().catch(err => {

--- a/ndc-lambda-sdk/test/execution/execute-mutation.test.ts
+++ b/ndc-lambda-sdk/test/execution/execute-mutation.test.ts
@@ -1,0 +1,162 @@
+import { describe, it } from "mocha";
+import { assert, expect } from "chai";
+import * as sdk from "@hasura/ndc-sdk-typescript"
+import { executeMutation } from "../../src/execution";
+import { FunctionNdcKind, FunctionsSchema } from "../../src/schema";
+
+describe("execute mutation", function() {
+  it("executes the function", async function() {
+    let functionCallCount = 0;
+    const runtimeFunctions = {
+      "theFunction": (param: string) => {
+        functionCallCount++;
+        return `Called with '${param}'`;
+      }
+    };
+    const functionSchema: FunctionsSchema = {
+      functions: {
+        "theFunction": {
+          ndcKind: FunctionNdcKind.Procedure,
+          description: null,
+          parallelDegree: null,
+          arguments: [
+            {
+              argumentName: "param",
+              description: null,
+              type: {
+                type: "named",
+                kind: "scalar",
+                name: "String"
+              }
+            },
+          ],
+          resultType: {
+            type: "named",
+            kind: "scalar",
+            name: "String"
+          }
+        }
+      },
+      objectTypes: {},
+      scalarTypes: {
+        "String": {}
+      }
+    };
+    const queryRequest: sdk.MutationRequest = {
+      operations: [
+        {
+          type: "procedure",
+          name: "theFunction",
+          fields: {},
+          arguments: {
+            "param": "test"
+          }
+        }
+      ],
+      collection_relationships: {}
+    };
+
+    const result = await executeMutation(queryRequest, functionSchema, runtimeFunctions);
+    assert.deepStrictEqual(result, {
+      operation_results: [
+        {
+          affected_rows: 1,
+          returning: [
+            { __value: "Called with 'test'" }
+          ]
+        }
+      ]
+    });
+    assert.equal(functionCallCount, 1);
+  });
+
+  describe("function error handling", function() {
+    const functionSchema: FunctionsSchema = {
+      functions: {
+        "theFunction": {
+          ndcKind: FunctionNdcKind.Procedure,
+          description: null,
+          parallelDegree: null,
+          arguments: [],
+          resultType: {
+            type: "named",
+            kind: "scalar",
+            name: "String"
+          }
+        }
+      },
+      objectTypes: {},
+      scalarTypes: {
+        "String": {}
+      }
+    };
+    const mutationRequest: sdk.MutationRequest = {
+      operations: [{
+        type: "procedure",
+        name: "theFunction",
+        arguments: {},
+        fields: {},
+      }],
+      collection_relationships: {}
+    };
+
+    it("Error -> sdk.InternalServerError", async function() {
+      const runtimeFunctions = {
+        "theFunction": () => {
+          throw new Error("BOOM!");
+        }
+      };
+
+      await expect(executeMutation(mutationRequest, functionSchema, runtimeFunctions))
+        .to.be.rejectedWith(sdk.InternalServerError, "Error encountered when invoking function 'theFunction'")
+        .which.eventually.has.property("details")
+        .which.include.keys("stack")
+        .and.has.property("message", "BOOM!");
+    });
+
+    it("string -> sdk.InternalServerError", async function() {
+      const runtimeFunctions = {
+        "theFunction": () => {
+          throw "A bad way to throw errors";
+        }
+      };
+
+      await expect(executeMutation(mutationRequest, functionSchema, runtimeFunctions))
+        .to.be.rejectedWith(sdk.InternalServerError, "Error encountered when invoking function 'theFunction'")
+        .which.eventually.has.property("details")
+        .and.has.property("message", "A bad way to throw errors");
+    });
+
+    it("unknown -> sdk.InternalServerError", async function() {
+      const runtimeFunctions = {
+        "theFunction": () => {
+          throw 666; // What are you even doing? 👊
+        }
+      };
+
+      await expect(executeMutation(mutationRequest, functionSchema, runtimeFunctions))
+        .to.be.rejectedWith(sdk.InternalServerError, "Error encountered when invoking function 'theFunction'");
+    });
+
+    describe("sdk exceptions are passed through", function() {
+      const exceptions = [
+        sdk.BadRequest, sdk.Forbidden, sdk.Conflict, sdk.UnprocessableContent, sdk.InternalServerError, sdk.NotSupported, sdk.BadGateway
+      ];
+
+      for (const exceptionCtor of exceptions) {
+        it(`sdk.${exceptionCtor.name}`, async function() {
+          const runtimeFunctions = {
+            "theFunction": () => {
+              throw new exceptionCtor("Nope!", { deets: "stuff" });
+            }
+          };
+
+          await expect(executeMutation(mutationRequest, functionSchema, runtimeFunctions))
+            .to.be.rejectedWith(exceptionCtor, "Nope!")
+            .and.eventually.property("details").deep.equals({"deets": "stuff"});
+        });
+      }
+    });
+  })
+
+});

--- a/ndc-lambda-sdk/test/execution/execute-mutation.test.ts
+++ b/ndc-lambda-sdk/test/execution/execute-mutation.test.ts
@@ -47,7 +47,7 @@ describe("execute mutation", function() {
         {
           type: "procedure",
           name: "theFunction",
-          fields: {},
+          fields: null,
           arguments: {
             "param": "test"
           }
@@ -60,10 +60,124 @@ describe("execute mutation", function() {
     assert.deepStrictEqual(result, {
       operation_results: [
         {
-          affected_rows: 1,
-          returning: [
-            { __value: "Called with 'test'" }
+          type: "procedure",
+          result: "Called with 'test'"
+        }
+      ]
+    });
+    assert.equal(functionCallCount, 1);
+  });
+
+  it("can select into the result using nested fields", async function() {
+    let functionCallCount = 0;
+    const runtimeFunctions = {
+      "theFunction": (param: string) => {
+        functionCallCount++;
+        return {
+          calledWithStr: `Called with '${param}'`,
+          param,
+          functionCallCount,
+        };
+      }
+    };
+    const functionSchema: FunctionsSchema = {
+      functions: {
+        "theFunction": {
+          ndcKind: FunctionNdcKind.Procedure,
+          description: null,
+          parallelDegree: null,
+          arguments: [
+            {
+              argumentName: "param",
+              description: null,
+              type: {
+                type: "named",
+                kind: "scalar",
+                name: "String"
+              }
+            },
+          ],
+          resultType: {
+            type: "named",
+            kind: "object",
+            name: "FunctionResult"
+          }
+        }
+      },
+      objectTypes: {
+        "FunctionResult": {
+          description: null,
+          properties: [
+            {
+              propertyName: "calledWithStr",
+              description: null,
+              type: {
+                type: "named",
+                kind: "scalar",
+                name: "String"
+              }
+            },
+            {
+              propertyName: "param",
+              description: null,
+              type: {
+                type: "named",
+                kind: "scalar",
+                name: "String"
+              }
+            },
+            {
+              propertyName: "functionCallCount",
+              description: null,
+              type: {
+                type: "named",
+                kind: "scalar",
+                name: "Float"
+              }
+            }
           ]
+        }
+      },
+      scalarTypes: {
+        "Float": {},
+        "String": {},
+      }
+    };
+    const mutationRequest: sdk.MutationRequest = {
+      operations: [
+        {
+          type: "procedure",
+          name: "theFunction",
+          fields: {
+            type: "object",
+            fields: {
+              "str": {
+                type: "column",
+                column: "calledWithStr",
+              },
+              "callCount": {
+                type: "column",
+                column: "functionCallCount"
+              }
+            }
+          },
+          arguments: {
+            "param": "test"
+          }
+        }
+      ],
+      collection_relationships: {}
+    };
+
+    const result = await executeMutation(mutationRequest, functionSchema, runtimeFunctions);
+    assert.deepStrictEqual(result, {
+      operation_results: [
+        {
+          type: "procedure",
+          result: {
+            str: "Called with 'test'",
+            callCount: 1
+          }
         }
       ]
     });
@@ -112,7 +226,7 @@ describe("execute mutation", function() {
         {
           type: "procedure",
           name: "theFunction",
-          fields: {},
+          fields: null,
           arguments: {
             "param": "test"
           }
@@ -120,7 +234,7 @@ describe("execute mutation", function() {
         {
           type: "procedure",
           name: "theFunction",
-          fields: {},
+          fields: null,
           arguments: {
             "param": "test2"
           }
@@ -159,7 +273,7 @@ describe("execute mutation", function() {
         type: "procedure",
         name: "theFunction",
         arguments: {},
-        fields: {},
+        fields: null,
       }],
       collection_relationships: {}
     };

--- a/ndc-lambda-sdk/test/execution/execute-query.test.ts
+++ b/ndc-lambda-sdk/test/execution/execute-query.test.ts
@@ -46,7 +46,12 @@ describe("execute query", function() {
     const queryRequest: sdk.QueryRequest = {
       collection: "theFunction",
       query: {
-        fields: {},
+        fields: {
+          __value: {
+            type: "column",
+            column: "__value",
+          }
+        },
       },
       arguments: {
         "param": {
@@ -60,7 +65,7 @@ describe("execute query", function() {
     const result = await executeQuery(queryRequest, functionSchema, runtimeFunctions);
     assert.deepStrictEqual(result, [
       {
-        aggregates: {},
+        aggregates: null,
         rows: [
           { __value: "Called with 'test'" }
         ]
@@ -118,7 +123,12 @@ describe("execute query", function() {
     const queryRequest: sdk.QueryRequest = {
       collection: "theFunction",
       query: {
-        fields: {},
+        fields: {
+          __value: {
+            type: "column",
+            column: "__value",
+          }
+        },
       },
       arguments: {
         "param": {
@@ -144,13 +154,13 @@ describe("execute query", function() {
     const result = await executeQuery(queryRequest, functionSchema, runtimeFunctions);
     assert.deepStrictEqual(result, [
       {
-        aggregates: {},
+        aggregates: null,
         rows: [
           { __value: "Called with 'test' and 'first'" }
         ]
       },
       {
-        aggregates: {},
+        aggregates: null,
         rows: [
           { __value: "Called with 'test' and 'second'" }
         ]
@@ -209,7 +219,12 @@ describe("execute query", function() {
     const queryRequest: sdk.QueryRequest = {
       collection: "theFunction",
       query: {
-        fields: {},
+        fields: {
+          __value: {
+            type: "column",
+            column: "__value",
+          }
+        },
       },
       arguments: {
         "invocationName": {
@@ -245,25 +260,25 @@ describe("execute query", function() {
     const result = await executeQuery(queryRequest, functionSchema, runtimeFunctions);
     assert.deepStrictEqual(result, [
       {
-        aggregates: {},
+        aggregates: null,
         rows: [
           { __value: "first" }
         ]
       },
       {
-        aggregates: {},
+        aggregates: null,
         rows: [
           { __value: "second" }
         ]
       },
       {
-        aggregates: {},
+        aggregates: null,
         rows: [
           { __value: "third" }
         ]
       },
       {
-        aggregates: {},
+        aggregates: null,
         rows: [
           { __value: "fourth" }
         ]
@@ -295,14 +310,14 @@ describe("execute query", function() {
     const queryRequest: sdk.QueryRequest = {
       collection: "theFunction",
       query: {
-        fields: {},
+        fields: {
+          __value: {
+            type: "column",
+            column: "__value",
+          }
+        },
       },
-      arguments: {
-        "param": {
-          type: "literal",
-          value: "test"
-        }
-      },
+      arguments: {},
       collection_relationships: {}
     };
 
@@ -364,4 +379,119 @@ describe("execute query", function() {
       }
     });
   })
+
+  describe("function calling convention", function() {
+    const functionSchema: FunctionsSchema = {
+      functions: {
+        "theFunction": {
+          ndcKind: FunctionNdcKind.Function,
+          description: null,
+          parallelDegree: null,
+          arguments: [],
+          resultType: {
+            type: "named",
+            kind: "scalar",
+            name: "String"
+          }
+        }
+      },
+      objectTypes: {},
+      scalarTypes: {
+        "String": {}
+      }
+    };
+
+    it("null fields produces null rows", async function() {
+      let functionCallCount = 0;
+      const runtimeFunctions = {
+        "theFunction": () => {
+          functionCallCount++;
+          return `Called ${functionCallCount} times total`;
+        }
+      };
+      const queryRequest: sdk.QueryRequest = {
+        collection: "theFunction",
+        query: {
+          fields: null
+        },
+        arguments: {},
+        collection_relationships: {}
+      };
+
+      const result = await executeQuery(queryRequest, functionSchema, runtimeFunctions);
+      assert.deepStrictEqual(result, [
+        {
+          aggregates: null,
+          rows: null
+        }
+      ]);
+      assert.equal(functionCallCount, 1);
+    });
+
+    it("empty fields produces one row with an empty result object", async function() {
+      let functionCallCount = 0;
+      const runtimeFunctions = {
+        "theFunction": () => {
+          functionCallCount++;
+          return `Called ${functionCallCount} times total`;
+        }
+      };
+      const queryRequest: sdk.QueryRequest = {
+        collection: "theFunction",
+        query: {
+          fields: {}
+        },
+        arguments: {},
+        collection_relationships: {}
+      };
+
+      const result = await executeQuery(queryRequest, functionSchema, runtimeFunctions);
+      assert.deepStrictEqual(result, [
+        {
+          aggregates: null,
+          rows: [{}]
+        }
+      ]);
+      assert.equal(functionCallCount, 1);
+    });
+
+    it("can duplicate virtual __value column", async function() {
+      let functionCallCount = 0;
+      const runtimeFunctions = {
+        "theFunction": () => {
+          functionCallCount++;
+          return `Called ${functionCallCount} times total`;
+        }
+      };
+      const queryRequest: sdk.QueryRequest = {
+        collection: "theFunction",
+        query: {
+          fields: {
+            value1: {
+              type: "column",
+              column: "__value"
+            },
+            value2: {
+              type: "column",
+              column: "__value"
+            }
+          }
+        },
+        arguments: {},
+        collection_relationships: {}
+      };
+
+      const result = await executeQuery(queryRequest, functionSchema, runtimeFunctions);
+      assert.deepStrictEqual(result, [
+        {
+          aggregates: null,
+          rows: [{
+            value1: "Called 1 times total",
+            value2: "Called 1 times total"
+          }]
+        }
+      ]);
+      assert.equal(functionCallCount, 1);
+    });
+  });
 });

--- a/ndc-lambda-sdk/test/execution/reshape-result.test.ts
+++ b/ndc-lambda-sdk/test/execution/reshape-result.test.ts
@@ -49,7 +49,7 @@ describe("reshape result", function() {
     for (const testCase of testCases) {
       it(testCase.testName, function () {
         const scalarType: NamedTypeDefinition = { type: "named", kind: "scalar", name: testCase.type };
-        const result = reshapeResultToNdcResponseValue(testCase.value, scalarType, [], "AllColumns", {});
+        const result = reshapeResultToNdcResponseValue(testCase.value, scalarType, null, {});
         assert.deepStrictEqual(result, testCase.reshapedValue);
       })
     }
@@ -80,7 +80,7 @@ describe("reshape result", function() {
     for (const testCase of testCases) {
       it(testCase.testName, function () {
         const nullableType: NullableTypeDefinition = { type: "nullable", nullOrUndefinability: NullOrUndefinability.AcceptsEither, underlyingType: { type: "named", kind: "scalar", name: testCase.scalarType } };
-        const result = reshapeResultToNdcResponseValue(testCase.value, nullableType, [], "AllColumns", {});
+        const result = reshapeResultToNdcResponseValue(testCase.value, nullableType, null, {});
         assert.strictEqual(result, testCase.reshapedValue);
       })
     }
@@ -113,7 +113,7 @@ describe("reshape result", function() {
       {
         testName: "AllColumns",
         value: { propA: "valueA", propB: "valueB", nested: { propA: "nestedValueA", propB: "nestedValueB" } },
-        fields: "AllColumns" as const,
+        fields: null,
         reshapedValue: { propA: "valueA", propB: "valueB", nested: { propA: "nestedValueA", propB: "nestedValueB", nested: null } },
       },
       {
@@ -151,7 +151,7 @@ describe("reshape result", function() {
     for (const testCase of testCases) {
       it(testCase.testName, function () {
         const objectType: NamedTypeDefinition = { type: "named", kind: "object", name: "TestObjectType" };
-        const result = reshapeResultToNdcResponseValue(testCase.value, objectType, [], testCase.fields, objectTypes);
+        const result = reshapeResultToNdcResponseValue(testCase.value, objectType, testCase.fields, objectTypes);
         assert.deepStrictEqual(result, testCase.reshapedValue);
       })
     }
@@ -159,7 +159,7 @@ describe("reshape result", function() {
 
   it("serializes scalar array type", function() {
     const arrayType: ArrayTypeDefinition = { type: "array", elementType: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.Float } };
-    const result = reshapeResultToNdcResponseValue([1,2,3], arrayType, [], "AllColumns", {});
+    const result = reshapeResultToNdcResponseValue([1,2,3], arrayType, null, {});
     assert.deepStrictEqual(result, [1,2,3]);
   });
 
@@ -188,7 +188,7 @@ describe("reshape result", function() {
           { propA: "valueA1", propB: "valueB1" },
           { propA: "valueA2", propB: "valueB2" },
         ],
-        fields: "AllColumns" as const,
+        fields: null,
         reshapedValue: [
           { propA: "valueA1", propB: "valueB1" },
           { propA: "valueA2", propB: "valueB2" },
@@ -231,7 +231,7 @@ describe("reshape result", function() {
         ],
       },
       {
-        testName: "propB, duplicatedPropB",
+        testName: "propB, duplicatedPropB:propB",
         value: [
           { propA: "valueA1", propB: "valueB1" },
           { propA: "valueA2", propB: "valueB2" },
@@ -259,7 +259,241 @@ describe("reshape result", function() {
     for (const testCase of testCases) {
       it(testCase.testName, function () {
         const arrayType: ArrayTypeDefinition = { type: "array", elementType: { type: "named", kind: "object", name: "TestObjectType" } };
-        const result = reshapeResultToNdcResponseValue(testCase.value, arrayType, [], testCase.fields, objectTypes);
+        const result = reshapeResultToNdcResponseValue(testCase.value, arrayType, testCase.fields, objectTypes);
+        assert.deepStrictEqual(result, testCase.reshapedValue);
+      })
+    }
+  });
+
+  describe("projects nested objects using nested fields", function() {
+    const objectTypes: ObjectTypeDefinitions = {
+      "TestObjectType": {
+        description: null,
+        properties: [
+          {
+            propertyName: "propA",
+            description: null,
+            type: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.String }
+          },
+          {
+            propertyName: "propB",
+            description: null,
+            type: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.String }
+          },
+          {
+            propertyName: "nested",
+            description: null,
+            type: { type: "nullable", nullOrUndefinability: NullOrUndefinability.AcceptsEither, underlyingType: { type: "named", kind: "object", name: "TestObjectType" } }
+          }
+        ]
+      }
+    }
+    const testCases = [
+      {
+        testName: "AllColumns",
+        value: { propA: "valueA", propB: "valueB", nested: { propA: "nestedValueA", propB: "nestedValueB" } },
+        fields: null,
+        reshapedValue: {
+          propA: "valueA",
+          propB: "valueB",
+          nested: { propA: "nestedValueA", propB: "nestedValueB", nested: null, },
+        },
+      },
+      {
+        testName: "nested.propA, nested.propB",
+        value: { propA: "valueA", propB: "valueB", nested: { propA: "nestedValueA", propB: "nestedValueB" } },
+        fields: <Record<string, sdk.Field>>{
+          nested: {
+            type: "column",
+            column: "nested",
+            fields: { type: "object", fields: { propA: { type: "column", column: "propA" }, propB: { type: "column", column: "propB" } } }
+          }
+        },
+        reshapedValue: { nested: { propA: "nestedValueA", propB: "nestedValueB" } },
+      },
+      {
+        testName: "nested.(renamedPropA:propA), nested.(renamedPropB:propB)",
+        value: { propA: "valueA", propB: "valueB", nested: { propA: "nestedValueA", propB: "nestedValueB" } },
+        fields: <Record<string, sdk.Field>>{
+          nested: {
+            type: "column",
+            column: "nested",
+            fields: { type: "object", fields: { renamedPropA: { type: "column", column: "propA" }, renamedPropB: { type: "column", column: "propB" } } }
+          }
+        },
+        reshapedValue: { nested: { renamedPropA: "nestedValueA", renamedPropB: "nestedValueB" } },
+      },
+      {
+        testName: "nested.propB",
+        value: { propA: "valueA", propB: "valueB", nested: { propA: "nestedValueA", propB: "nestedValueB" } },
+        fields: <Record<string, sdk.Field>>{
+          nested: {
+            type: "column",
+            column: "nested",
+            fields: { type: "object", fields: { propB: { type: "column", column: "propB" } } }
+          }
+        },
+        reshapedValue: { nested: { propB: "nestedValueB" } },
+      },
+      {
+        testName: "nested.propB, nested.(duplicatedPropB:propB}",
+        value: { propA: "valueA", propB: "valueB", nested: { propA: "nestedValueA", propB: "nestedValueB" } },
+        fields: <Record<string, sdk.Field>>{
+          nested: {
+            type: "column",
+            column: "nested",
+            fields: { type: "object", fields: { propB: { type: "column", column: "propB" }, duplicatedPropB: { type: "column", column: "propB" } } }
+          }
+        },
+        reshapedValue: { nested: { propB: "nestedValueB", duplicatedPropB: "nestedValueB" } },
+      },
+      {
+        testName: "nested.(missingProp:nested)",
+        value: { propA: "valueA", propB: "valueB", nested: { propA: "nestedValueA", propB: "nestedValueB" } },
+        fields: <Record<string, sdk.Field>>{
+          nested: {
+            type: "column",
+            column: "nested",
+            fields: { type: "object", fields: { missingProp: { type: "column", column: "nested" } } }
+          }
+        },
+        reshapedValue: { nested: { missingProp: null } },
+      },
+    ]
+
+    for (const testCase of testCases) {
+      it(testCase.testName, function () {
+        const objectType: NamedTypeDefinition = { type: "named", kind: "object", name: "TestObjectType" };
+        const result = reshapeResultToNdcResponseValue(testCase.value, objectType, testCase.fields, objectTypes);
+        assert.deepStrictEqual(result, testCase.reshapedValue);
+      })
+    }
+  });
+
+  describe("projects nested arrays using nested fields", function() {
+    const objectTypes: ObjectTypeDefinitions = {
+      "TestObjectType": {
+        description: null,
+        properties: [
+          {
+            propertyName: "propA",
+            description: null,
+            type: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.String }
+          },
+          {
+            propertyName: "propB",
+            description: null,
+            type: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.String }
+          },
+          {
+            propertyName: "nestedArray",
+            description: null,
+            type: { type: "nullable", nullOrUndefinability: NullOrUndefinability.AcceptsEither, underlyingType: { type: "array", elementType: { type: "named", kind: "object", name: "TestObjectType" } } }
+          }
+        ]
+      }
+    }
+    const testCases = [
+      {
+        testName: "AllColumns",
+        value: {
+          propA: "valueA",
+          propB: "valueB",
+          nestedArray: [ { propA: "nestedArrayValue1A", propB: "nestedArrayValue1B" }, { propA: "nestedArrayValue2A", propB: "nestedArrayValue2B" } ]
+        },
+        fields: null,
+        reshapedValue: {
+          propA: "valueA",
+          propB: "valueB",
+          nestedArray: [ { propA: "nestedArrayValue1A", propB: "nestedArrayValue1B", nestedArray: null }, { propA: "nestedArrayValue2A", propB: "nestedArrayValue2B", nestedArray: null } ]
+        },
+      },
+      {
+        testName: "nestedArray.propA, nestedArray.propB",
+        value: {
+          propA: "valueA",
+          propB: "valueB",
+          nestedArray: [ { propA: "nestedArrayValue1A", propB: "nestedArrayValue1B" }, { propA: "nestedArrayValue2A", propB: "nestedArrayValue2B" } ]
+        },
+        fields: <Record<string, sdk.Field>>{
+          nestedArray: {
+            type: "column",
+            column: "nestedArray",
+            fields: { type: "array", fields: { type: "object", fields: { propA: { type: "column", column: "propA" }, propB: { type: "column", column: "propB" } } } }
+          }
+        },
+        reshapedValue: { nestedArray: [ { propA: "nestedArrayValue1A", propB: "nestedArrayValue1B" }, { propA: "nestedArrayValue2A", propB: "nestedArrayValue2B" } ] },
+      },
+      {
+        testName: "nestedArray.(renamedPropA:propA), nestedArray.(renamedPropB:propB)",
+        value: {
+          propA: "valueA",
+          propB: "valueB",
+          nestedArray: [ { propA: "nestedArrayValue1A", propB: "nestedArrayValue1B" }, { propA: "nestedArrayValue2A", propB: "nestedArrayValue2B" } ]
+        },
+        fields: <Record<string, sdk.Field>>{
+          nestedArray: {
+            type: "column",
+            column: "nestedArray",
+            fields: { type: "array", fields: { type: "object", fields: { renamedPropA: { type: "column", column: "propA" }, renamedPropB: { type: "column", column: "propB" } } } }
+          }
+        },
+        reshapedValue: { nestedArray: [ { renamedPropA: "nestedArrayValue1A", renamedPropB: "nestedArrayValue1B" }, { renamedPropA: "nestedArrayValue2A", renamedPropB: "nestedArrayValue2B" } ] },
+      },
+      {
+        testName: "nestedArray.propB",
+        value: {
+          propA: "valueA",
+          propB: "valueB",
+          nestedArray: [ { propA: "nestedArrayValue1A", propB: "nestedArrayValue1B" }, { propA: "nestedArrayValue2A", propB: "nestedArrayValue2B" } ]
+        },
+        fields: <Record<string, sdk.Field>>{
+          nestedArray: {
+            type: "column",
+            column: "nestedArray",
+            fields: { type: "array", fields: { type: "object", fields: { propB: { type: "column", column: "propB" } } } }
+          }
+        },
+        reshapedValue: { nestedArray: [ { propB: "nestedArrayValue1B" }, { propB: "nestedArrayValue2B" } ] },
+      },
+      {
+        testName: "nestedArray.propB, nestedArray.(duplicatedPropB:propB}",
+        value: {
+          propA: "valueA",
+          propB: "valueB",
+          nestedArray: [ { propA: "nestedArrayValue1A", propB: "nestedArrayValue1B" }, { propA: "nestedArrayValue2A", propB: "nestedArrayValue2B" } ]
+        },
+        fields: <Record<string, sdk.Field>>{
+          nestedArray: {
+            type: "column",
+            column: "nestedArray",
+            fields: { type: "array", fields: { type: "object", fields: { propB: { type: "column", column: "propB" }, duplicatedPropB: { type: "column", column: "propB" } } } }
+          }
+        },
+        reshapedValue: { nestedArray: [ { propB: "nestedArrayValue1B", duplicatedPropB: "nestedArrayValue1B" }, { propB: "nestedArrayValue2B", duplicatedPropB: "nestedArrayValue2B" } ] },
+      },
+      {
+        testName: "nestedArray.(missingProp:nested)",
+        value: {
+          propA: "valueA",
+          propB: "valueB",
+          nestedArray: [ { propA: "nestedArrayValue1A", propB: "nestedArrayValue1B" }, { propA: "nestedArrayValue2A", propB: "nestedArrayValue2B" } ]
+        },
+        fields: <Record<string, sdk.Field>>{
+          nestedArray: {
+            type: "column",
+            column: "nestedArray",
+            fields: { type: "array", fields: { type: "object", fields: { missingProp: { type: "column", column: "nestedArray" } } } }
+          }
+        },
+        reshapedValue: { nestedArray: [ { missingProp: null }, { missingProp: null } ] },
+      },
+    ]
+
+    for (const testCase of testCases) {
+      it(testCase.testName, function () {
+        const objectType: NamedTypeDefinition = { type: "named", kind: "object", name: "TestObjectType" };
+        const result = reshapeResultToNdcResponseValue(testCase.value, objectType, testCase.fields, objectTypes);
         assert.deepStrictEqual(result, testCase.reshapedValue);
       })
     }

--- a/yeoman-generator/package-lock.json
+++ b/yeoman-generator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-hasura-ndc-nodejs-lambda",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
This PR updates the `ndc-typescript-sdk` to v3.0.0 which brings support for the NDC Spec v0.1.0-rc.15. Note that this is a breaking change, so it will need to be used with the latest Hasura engine that supports the new spec for it to work.

This spec revision (added to the rc.14 revision) adds support for nested object/array selection in the response. This allows callers to only return a subset of the function return type if they wish. It also introduces a new function calling convention that relies upon nested object field selection, as well as a change the mutations request/response types.

Query requests now are expected to query for a virtual column called `__value` and use nested object queries to select into that value. This virtual column exists on the virtual row that is returned that encapsulates the function return value.

This PR also adds new unit tests to cover the execution of mutations.

JIRA: [NDC-307](https://hasurahq.atlassian.net/browse/NDC-307)

[NDC-307]: https://hasurahq.atlassian.net/browse/NDC-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ