### PR TITLE
Support for relaxed types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog documents the changes between release versions.
 ## main
 Changes to be included in the next upcoming release
 
+* Support for "relaxed types" ([#10](https://github.com/hasura/ndc-nodejs-lambda/pull/10))
+
 ## v0.13.0
 - Add support for treating 'true | false' as a Boolean type ([#7](https://github.com/hasura/ndc-nodejs-lambda/pull/7))
 

--- a/ndc-lambda-sdk/src/connector.ts
+++ b/ndc-lambda-sdk/src/connector.ts
@@ -1,7 +1,7 @@
 import * as sdk from "@hasura/ndc-sdk-typescript";
 import { JSONSchemaObject } from "@json-schema-tools/meta-schema";
 import path from "node:path"
-import { FunctionsSchema, getNdcSchema } from "./schema";
+import { FunctionsSchema, getNdcSchema, printRelaxedTypesWarning } from "./schema";
 import { deriveSchema, printCompilerDiagnostics, printFunctionIssues } from "./inference";
 import { RuntimeFunctions, executeMutation, executeQuery } from "./execution";
 
@@ -45,6 +45,7 @@ export function createConnector(options: ConnectorOptions): sdk.Connector<RawCon
       const schemaResults = deriveSchema(functionsFilePath);
       printCompilerDiagnostics(schemaResults.compilerDiagnostics);
       printFunctionIssues(schemaResults.functionIssues);
+      printRelaxedTypesWarning(schemaResults.functionsSchema);
       return {
         functionsSchema: schemaResults.functionsSchema
       }

--- a/ndc-lambda-sdk/src/execution.ts
+++ b/ndc-lambda-sdk/src/execution.ts
@@ -107,7 +107,7 @@ export function prepareArguments(args: Record<string, unknown>, functionDefiniti
   return functionDefinition.arguments.map(argDef => coerceArgumentValue(args[argDef.argumentName], argDef.type, [argDef.argumentName], objectTypes));
 }
 
-function coerceArgumentValue(value: unknown, type: schema.TypeDefinition, valuePath: string[], objectTypeDefinitions: schema.ObjectTypeDefinitions): unknown {
+function coerceArgumentValue(value: unknown, type: schema.TypeReference, valuePath: string[], objectTypeDefinitions: schema.ObjectTypeDefinitions): unknown {
   switch (type.type) {
     case "array":
       if (!isArray(value))
@@ -128,7 +128,7 @@ function coerceArgumentValue(value: unknown, type: schema.TypeDefinition, valueP
       }
     case "named":
       if (type.kind === "scalar") {
-        if (schema.isBuiltInScalarTypeDefinition(type))
+        if (schema.isBuiltInScalarTypeReference(type))
           return convertBuiltInNdcJsonScalarToJsScalar(value, valuePath, type);
         // Scalars are currently treated as opaque values, which is a bit dodgy
         return value;
@@ -211,7 +211,7 @@ function buildCausalStackTrace(error: Error): string {
   return stackTrace;
 }
 
-export function reshapeResultToNdcResponseValue(value: unknown, type: schema.TypeDefinition, valuePath: string[], fields: Record<string, sdk.Field> | "AllColumns", objectTypes: schema.ObjectTypeDefinitions): unknown {
+export function reshapeResultToNdcResponseValue(value: unknown, type: schema.TypeReference, valuePath: string[], fields: Record<string, sdk.Field> | "AllColumns", objectTypes: schema.ObjectTypeDefinitions): unknown {
   switch (type.type) {
     case "array":
       if (isArray(value)) {
@@ -268,7 +268,7 @@ export function reshapeResultToNdcResponseValue(value: unknown, type: schema.Typ
   }
 }
 
-function convertBuiltInNdcJsonScalarToJsScalar(value: unknown, valuePath: string[], scalarType: schema.BuiltInScalarTypeDefinition): string | number | boolean | BigInt | Date | schema.JSONValue {
+function convertBuiltInNdcJsonScalarToJsScalar(value: unknown, valuePath: string[], scalarType: schema.BuiltInScalarTypeReference): string | number | boolean | BigInt | Date | schema.JSONValue {
   switch (scalarType.name) {
     case schema.BuiltInScalarTypeName.String:
       if (typeof value === "string") {

--- a/ndc-lambda-sdk/src/result.ts
+++ b/ndc-lambda-sdk/src/result.ts
@@ -28,6 +28,17 @@ abstract class ResultBase<T, TError> {
       throw new Error("Unknown result subclass");
     }
   }
+
+  onErr(fn: (r: TError) => void): Result<T, TError> {
+    if (this instanceof Ok) {
+      return this;
+    } else if (this instanceof Err) {
+      fn(this.error)
+      return this;
+    } else {
+      throw new Error("Unknown result subclass");
+    }
+  }
 }
 
 export class Ok<T, TError> extends ResultBase<T, TError> {
@@ -50,11 +61,11 @@ export class Err<T, TError> extends ResultBase<T, TError> {
 
 export type Result<T, TError> = Ok<T, TError> | Err<T, TError>
 
-function traverseAndCollectErrors<T1, T2, TErr>(inputs: T1[], fn: (input: T1) => Result<T2, TErr[]>): Result<T2[], TErr[]> {
+function traverseAndCollectErrors<T1, T2, TErr>(inputs: readonly T1[], fn: (input: T1, index: number) => Result<T2, TErr[]>): Result<T2[], TErr[]> {
   return sequenceAndCollectErrors(inputs.map(fn))
 }
 
-function sequenceAndCollectErrors<T, TErr>(results: Result<T, TErr[]>[]): Result<T[], TErr[]> {
+function sequenceAndCollectErrors<T, TErr>(results: readonly Result<T, TErr[]>[]): Result<T[], TErr[]> {
   const data: T[] = [];
   const errors: TErr[] = [];
 
@@ -71,7 +82,7 @@ function sequenceAndCollectErrors<T, TErr>(results: Result<T, TErr[]>[]): Result
     : new Ok(data);
 }
 
-function partitionAndCollectErrors<T, TErr>(results: Result<T, TErr[]>[]): { oks: T[], errs: TErr[] } {
+function partitionAndCollectErrors<T, TErr>(results: readonly Result<T, TErr[]>[]): { oks: T[], errs: TErr[] } {
   const partitionedResults: { oks: T[], errs: TErr[] } = {
     oks: [],
     errs: [],

--- a/ndc-lambda-sdk/test/execution/execute-query.test.ts
+++ b/ndc-lambda-sdk/test/execution/execute-query.test.ts
@@ -40,7 +40,7 @@ describe("execute query", function() {
       },
       objectTypes: {},
       scalarTypes: {
-        "String": {}
+        "String": { type: "built-in" }
       }
     };
     const queryRequest: sdk.QueryRequest = {
@@ -112,7 +112,7 @@ describe("execute query", function() {
       },
       objectTypes: {},
       scalarTypes: {
-        "String": {}
+        "String": { type: "built-in" }
       }
     };
     const queryRequest: sdk.QueryRequest = {
@@ -203,7 +203,7 @@ describe("execute query", function() {
       },
       objectTypes: {},
       scalarTypes: {
-        "String": {}
+        "String": { type: "built-in" }
       }
     };
     const queryRequest: sdk.QueryRequest = {
@@ -289,7 +289,7 @@ describe("execute query", function() {
       },
       objectTypes: {},
       scalarTypes: {
-        "String": {}
+        "String": { type: "built-in" }
       }
     };
     const queryRequest: sdk.QueryRequest = {

--- a/ndc-lambda-sdk/test/execution/prepare-arguments.test.ts
+++ b/ndc-lambda-sdk/test/execution/prepare-arguments.test.ts
@@ -209,7 +209,8 @@ describe("prepare arguments", function() {
               }
             }
           }
-        ]
+        ],
+        isRelaxedType: false,
       }
     }
     const testCases = [

--- a/ndc-lambda-sdk/test/execution/reshape-result.test.ts
+++ b/ndc-lambda-sdk/test/execution/reshape-result.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "mocha";
 import { assert } from "chai";
 import * as sdk from "@hasura/ndc-sdk-typescript"
 import { reshapeResultToNdcResponseValue } from "../../src/execution";
-import { ArrayTypeDefinition, BuiltInScalarTypeName, JSONValue, NamedTypeDefinition, NullOrUndefinability, NullableTypeDefinition, ObjectTypeDefinitions } from "../../src/schema";
+import { ArrayTypeReference, BuiltInScalarTypeName, JSONValue, NamedTypeReference, NullOrUndefinability, NullableTypeReference, ObjectTypeDefinitions } from "../../src/schema";
 
 describe("reshape result", function() {
 
@@ -48,7 +48,7 @@ describe("reshape result", function() {
 
     for (const testCase of testCases) {
       it(testCase.testName, function () {
-        const scalarType: NamedTypeDefinition = { type: "named", kind: "scalar", name: testCase.type };
+        const scalarType: NamedTypeReference = { type: "named", kind: "scalar", name: testCase.type };
         const result = reshapeResultToNdcResponseValue(testCase.value, scalarType, [], "AllColumns", {});
         assert.deepStrictEqual(result, testCase.reshapedValue);
       })
@@ -79,7 +79,7 @@ describe("reshape result", function() {
 
     for (const testCase of testCases) {
       it(testCase.testName, function () {
-        const nullableType: NullableTypeDefinition = { type: "nullable", nullOrUndefinability: NullOrUndefinability.AcceptsEither, underlyingType: { type: "named", kind: "scalar", name: testCase.scalarType } };
+        const nullableType: NullableTypeReference = { type: "nullable", nullOrUndefinability: NullOrUndefinability.AcceptsEither, underlyingType: { type: "named", kind: "scalar", name: testCase.scalarType } };
         const result = reshapeResultToNdcResponseValue(testCase.value, nullableType, [], "AllColumns", {});
         assert.strictEqual(result, testCase.reshapedValue);
       })
@@ -106,7 +106,8 @@ describe("reshape result", function() {
             description: null,
             type: { type: "nullable", nullOrUndefinability: NullOrUndefinability.AcceptsEither, underlyingType: { type: "named", kind: "object", name: "TestObjectType" } }
           }
-        ]
+        ],
+        isRelaxedType: false,
       }
     }
     const testCases = [
@@ -150,7 +151,7 @@ describe("reshape result", function() {
 
     for (const testCase of testCases) {
       it(testCase.testName, function () {
-        const objectType: NamedTypeDefinition = { type: "named", kind: "object", name: "TestObjectType" };
+        const objectType: NamedTypeReference = { type: "named", kind: "object", name: "TestObjectType" };
         const result = reshapeResultToNdcResponseValue(testCase.value, objectType, [], testCase.fields, objectTypes);
         assert.deepStrictEqual(result, testCase.reshapedValue);
       })
@@ -158,7 +159,7 @@ describe("reshape result", function() {
   });
 
   it("serializes scalar array type", function() {
-    const arrayType: ArrayTypeDefinition = { type: "array", elementType: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.Float } };
+    const arrayType: ArrayTypeReference = { type: "array", elementType: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.Float } };
     const result = reshapeResultToNdcResponseValue([1,2,3], arrayType, [], "AllColumns", {});
     assert.deepStrictEqual(result, [1,2,3]);
   });
@@ -178,7 +179,8 @@ describe("reshape result", function() {
             description: null,
             type: { type: "nullable", nullOrUndefinability: NullOrUndefinability.AcceptsEither, underlyingType: { type: "named", kind: "scalar", name: BuiltInScalarTypeName.String } }
           }
-        ]
+        ],
+        isRelaxedType: false,
       }
     }
     const testCases = [
@@ -258,7 +260,7 @@ describe("reshape result", function() {
 
     for (const testCase of testCases) {
       it(testCase.testName, function () {
-        const arrayType: ArrayTypeDefinition = { type: "array", elementType: { type: "named", kind: "object", name: "TestObjectType" } };
+        const arrayType: ArrayTypeReference = { type: "array", elementType: { type: "named", kind: "object", name: "TestObjectType" } };
         const result = reshapeResultToNdcResponseValue(testCase.value, arrayType, [], testCase.fields, objectTypes);
         assert.deepStrictEqual(result, testCase.reshapedValue);
       })

--- a/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
+++ b/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
@@ -12,12 +12,12 @@ describe("basic inference", function() {
       functionIssues: {},
       functionsSchema: {
         scalarTypes: {
-          BigInt: {},
-          Boolean: {},
-          Float: {},
-          String: {},
-          DateTime: {},
-          JSON: {},
+          BigInt: { type: "built-in" },
+          Boolean: { type: "built-in" },
+          Float: { type: "built-in" },
+          String: { type: "built-in" },
+          DateTime: { type: "built-in" },
+          JSON: { type: "built-in" },
         },
         objectTypes: {},
         functions: {
@@ -203,12 +203,13 @@ describe("basic inference", function() {
                   type: "named",
                 },
               },
-            ]
+            ],
+            isRelaxedType: false,
           },
         },
         scalarTypes: {
-          Float: {},
-          String: {},
+          Float: { type: "built-in" },
+          String: { type: "built-in" },
         }
       }
     })
@@ -404,7 +405,8 @@ describe("basic inference", function() {
                   type: "named",
                 },
               },
-            ]
+            ],
+            isRelaxedType: false,
           },
           "GenericBar<string>": {
             description: null,
@@ -419,6 +421,7 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
           "GenericIntersectionObject<string>": {
             description: null,
@@ -442,6 +445,7 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
           "Bar": {
             description: null,
@@ -456,6 +460,7 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
           "IGenericThing<string>": {
             description: null,
@@ -470,6 +475,7 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
           "AliasedIGenericThing<number>": {
             description: null,
@@ -484,6 +490,7 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
           "AliasedClosedIGenericThing": {
             description: null,
@@ -498,6 +505,7 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
           "IThing": {
             description: null,
@@ -512,6 +520,7 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
           "IntersectionObject": {
             description: null,
@@ -535,6 +544,7 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
           "bar_arguments_anonIntersectionObj": {
             description: null,
@@ -558,6 +568,7 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
           "bar_arguments_anonObj": {
             description: null,
@@ -581,12 +592,13 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
         },
         scalarTypes: {
-          Boolean: {},
-          Float: {},
-          String: {},
+          Boolean: { type: "built-in" },
+          Float: { type: "built-in" },
+          String: { type: "built-in" },
         }
       }
     })
@@ -757,11 +769,12 @@ describe("basic inference", function() {
                 },
               },
             ],
+            isRelaxedType: false,
           },
         },
         scalarTypes: {
-          Boolean: {},
-          String: {},
+          Boolean: { type: "built-in" },
+          String: { type: "built-in" },
         },
       }
     })
@@ -812,11 +825,12 @@ describe("basic inference", function() {
                   }
                 }
               }
-            ]
+            ],
+            isRelaxedType: false,
           },
         },
         scalarTypes: {
-          Float: {},
+          Float: { type: "built-in" },
         },
       }
     })
@@ -830,10 +844,10 @@ describe("basic inference", function() {
       functionIssues: {},
       functionsSchema: {
         scalarTypes: {
-          BigInt: {},
-          Boolean: {},
-          Float: {},
-          String: {},
+          BigInt: { type: "built-in" },
+          Boolean: { type: "built-in" },
+          Float: { type: "built-in" },
+          String: { type: "built-in" },
         },
         functions: {
           "literalTypes": {
@@ -912,7 +926,8 @@ describe("basic inference", function() {
                   literalValue: 0,
                 }
               }
-            ]
+            ],
+            isRelaxedType: false,
           }
         },
       }

--- a/ndc-lambda-sdk/test/inference/external-dependencies/external-dependencies.test.ts
+++ b/ndc-lambda-sdk/test/inference/external-dependencies/external-dependencies.test.ts
@@ -12,7 +12,7 @@ describe("external dependencies", function() {
       functionIssues: {},
       functionsSchema: {
         scalarTypes: {
-          String: {},
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {
@@ -124,8 +124,8 @@ describe("external dependencies", function() {
           },
         },
         scalarTypes: {
-          String: {},
-          JSON: {}
+          String: { type: "built-in" },
+          JSON: { type: "built-in" },
         },
         objectTypes: {
           "delete_todos_output": {
@@ -157,7 +157,8 @@ describe("external dependencies", function() {
                   }
                 }
               }
-            ]
+            ],
+            isRelaxedType: false,
           }
         },
       }

--- a/ndc-lambda-sdk/test/inference/naming-conflicts/naming-conflicts.test.ts
+++ b/ndc-lambda-sdk/test/inference/naming-conflicts/naming-conflicts.test.ts
@@ -46,7 +46,8 @@ describe("naming conflicts", function() {
                   type: "named",
                 },
               },
-            ]
+            ],
+            isRelaxedType: false,
           },
           "conflict_from_import_dep_Foo": {
             description: null,
@@ -69,13 +70,14 @@ describe("naming conflicts", function() {
                   type: "named",
                 },
               },
-            ]
+            ],
+            isRelaxedType: false,
           },
         },
         scalarTypes: {
-          Boolean: {},
-          Float: {},
-          String: {},
+          Boolean: { type: "built-in" },
+          Float: { type: "built-in" },
+          String: { type: "built-in" },
         }
       }
     })

--- a/ndc-lambda-sdk/test/inference/parallel-degree/parallel-degree.test.ts
+++ b/ndc-lambda-sdk/test/inference/parallel-degree/parallel-degree.test.ts
@@ -36,7 +36,7 @@ describe("parallel degree", function() {
           },
         },
         scalarTypes: {
-          String: {},
+          String: { type: "built-in" },
         },
         objectTypes: {},
       }
@@ -65,7 +65,7 @@ describe("parallel degree", function() {
       functionsSchema: {
         functions: {},
         scalarTypes: {
-          String: {},
+          String: { type: "built-in" },
         },
         objectTypes: {},
       }

--- a/ndc-lambda-sdk/test/inference/re-exported-functions/re-exported-functions.test.ts
+++ b/ndc-lambda-sdk/test/inference/re-exported-functions/re-exported-functions.test.ts
@@ -78,9 +78,9 @@ describe("re-exported functions", function() {
           },
         },
         scalarTypes: {
-          Boolean: {},
-          Float: {},
-          String: {},
+          Boolean: { type: "built-in" },
+          Float: { type: "built-in" },
+          String: { type: "built-in" },
         },
         objectTypes: {},
       }
@@ -150,8 +150,8 @@ describe("re-exported functions", function() {
           },
         },
         scalarTypes: {
-          Float: {},
-          String: {},
+          Float: { type: "built-in" },
+          String: { type: "built-in" },
         },
         objectTypes: {},
       }
@@ -200,7 +200,7 @@ describe("re-exported functions", function() {
           },
         },
         scalarTypes: {
-          String: {},
+          String: { type: "built-in" },
         },
         objectTypes: {},
       }

--- a/ndc-lambda-sdk/test/inference/relaxed-types/any.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/any.ts
@@ -1,0 +1,4 @@
+/** @allowrelaxedtypes */
+export function anyFunction(test: any): any {
+  return "wow";
+}

--- a/ndc-lambda-sdk/test/inference/relaxed-types/index-signature-types-invalid.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/index-signature-types-invalid.ts
@@ -1,0 +1,28 @@
+type ObjectWithIndexSignature = { [name: string]: never }
+
+type ObjectWithPropsAndIndexSignature = {
+  propA: Promise<string>
+  propB: Promise<string>
+  [propName: string]: Promise<string>
+}
+
+type MyType1 = {
+  [index: number]: string;
+};
+
+type MyType2 = {
+  [key: string]: Promise<string>;
+};
+
+type IntersectionOfMultipleIndexSigs = MyType1 & MyType2
+
+/** @allowrelaxedtypes */
+export function indexSignatureTypesFunction(
+  recordType: Record<string, void>,
+  inlineSig: { [x: string]: undefined },
+  objWithSig: ObjectWithIndexSignature,
+  objWithPropsAndSig: ObjectWithPropsAndIndexSignature,
+  intersectionSigs: IntersectionOfMultipleIndexSigs
+): string {
+  return ""
+}

--- a/ndc-lambda-sdk/test/inference/relaxed-types/index-signature-types-valid.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/index-signature-types-valid.ts
@@ -1,0 +1,28 @@
+type ObjectWithIndexSignature = { [name: string]: string }
+
+type ObjectWithPropsAndIndexSignature = {
+  propA: string
+  propB: string
+  [propName: string]: string
+}
+
+type MyType1 = {
+  [index: number]: string;
+};
+
+type MyType2 = {
+  [key: string]: number;
+};
+
+type IntersectionOfMultipleIndexSigs = MyType1 & MyType2
+
+/** @allowrelaxedtypes */
+export function indexSignatureTypesFunction(
+  recordType: Record<string, string>,
+  inlineSig: { [x: string]: string },
+  objWithSig: ObjectWithIndexSignature,
+  objWithPropsAndSig: ObjectWithPropsAndIndexSignature,
+  intersectionSigs: IntersectionOfMultipleIndexSigs
+): string {
+  return ""
+}

--- a/ndc-lambda-sdk/test/inference/relaxed-types/relaxed-types.test.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/relaxed-types.test.ts
@@ -1,0 +1,579 @@
+import { describe, it } from "mocha";
+import { assert } from "chai";
+import { deriveSchema } from "../../../src/inference";
+import { FunctionNdcKind } from "../../../src/schema";
+
+describe("relaxed types", function() {
+  it("any", function() {
+    const schema = deriveSchema(require.resolve("./any.ts"));
+
+    assert.deepStrictEqual(schema, {
+      compilerDiagnostics: [],
+      functionIssues: {},
+      functionsSchema: {
+        scalarTypes: {
+          "any": {
+            type: "relaxed-type",
+            usedIn: [
+              [
+                {
+                  functionName: "anyFunction",
+                  parameterName: "test",
+                  segmentType: "FunctionParameter",
+                }
+              ],
+              [
+                {
+                  functionName: "anyFunction",
+                  segmentType: "FunctionReturn",
+                }
+              ]
+            ]
+          },
+        },
+        objectTypes: {},
+        functions: {
+          "anyFunction": {
+            description: null,
+            ndcKind: FunctionNdcKind.Procedure,
+            parallelDegree: null,
+            arguments: [
+              {
+                argumentName: "test",
+                description: null,
+                type: {
+                  type: "named",
+                  kind: "scalar",
+                  name: "any",
+                }
+              }
+            ],
+            resultType: {
+              type: "named",
+              kind: "scalar",
+              name: "any",
+            }
+          }
+        }
+      }
+    })
+  });
+
+  it("unknown", function() {
+    const schema = deriveSchema(require.resolve("./unknown.ts"));
+
+    assert.deepStrictEqual(schema, {
+      compilerDiagnostics: [],
+      functionIssues: {},
+      functionsSchema: {
+        scalarTypes: {
+          "String": { type: "built-in" },
+          "unknown": {
+            type: "relaxed-type",
+            usedIn: [
+              [
+                {
+                  functionName: "unknownFunction",
+                  parameterName: "test",
+                  segmentType: "FunctionParameter",
+                }
+              ]
+            ]
+          },
+        },
+        objectTypes: {},
+        functions: {
+          "unknownFunction": {
+            description: null,
+            ndcKind: FunctionNdcKind.Procedure,
+            parallelDegree: null,
+            arguments: [
+              {
+                argumentName: "test",
+                description: null,
+                type: {
+                  type: "named",
+                  kind: "scalar",
+                  name: "unknown",
+                }
+              }
+            ],
+            resultType: {
+              type: "named",
+              kind: "scalar",
+              name: "String",
+            }
+          }
+        }
+      }
+    })
+  });
+
+  describe("tuple types", function() {
+    it("valid", function() {
+      const schema = deriveSchema(require.resolve("./tuple-types-valid.ts"));
+
+      assert.deepStrictEqual(schema, {
+        compilerDiagnostics: [],
+        functionIssues: {},
+        functionsSchema: {
+          scalarTypes: {
+            "String": { type: "built-in" },
+            "[string]": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "tupleFunction",
+                    parameterName: "tuple1",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "[string, number]": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "tupleFunction",
+                    parameterName: "tuple2",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "Tuple<number, boolean>": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "tupleFunction",
+                    parameterName: "tupleAlias",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+          },
+          objectTypes: {},
+          functions: {
+            "tupleFunction": {
+              description: null,
+              ndcKind: FunctionNdcKind.Procedure,
+              parallelDegree: null,
+              arguments: [
+                {
+                  argumentName: "tuple1",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "[string]",
+                  }
+                },
+                {
+                  argumentName: "tuple2",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "[string, number]",
+                  }
+                },
+                {
+                  argumentName: "tupleAlias",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "Tuple<number, boolean>",
+                  }
+                },
+              ],
+              resultType: {
+                type: "named",
+                kind: "scalar",
+                name: "String",
+              }
+            },
+          }
+        }
+      })
+    });
+
+    it("invalid", function() {
+      const schema = deriveSchema(require.resolve("./tuple-types-invalid.ts"));
+
+      assert.deepStrictEqual(schema, {
+        compilerDiagnostics: [],
+        functionIssues: {
+          "tupleFunction": [
+            "The void type is not supported, but one was encountered in function 'tupleFunction' parameter 'tuple1', type '[void]' type parameter index '0'",
+            "The never type is not supported, but one was encountered in function 'tupleFunction' parameter 'tuple2', type '[string, never]' type parameter index '1'",
+            "Promise types are not supported, but one was encountered in function 'tupleFunction' parameter 'tupleAlias', type 'Tuple<number, Promise<boolean>>' type parameter index '1'.",
+          ]
+        },
+        functionsSchema: {
+          scalarTypes: {
+            "String": { type: "built-in" },
+          },
+          objectTypes: {},
+          functions: {}
+        }
+      })
+    });
+  });
+
+  describe("index signature types", function() {
+    it("valid", function() {
+      const schema = deriveSchema(require.resolve("./index-signature-types-valid.ts"));
+
+      assert.deepStrictEqual(schema, {
+        compilerDiagnostics: [],
+        functionIssues: {},
+        functionsSchema: {
+          scalarTypes: {
+            "String": { type: "built-in" },
+            "Record<string, string>": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "indexSignatureTypesFunction",
+                    parameterName: "recordType",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "{ [x: string]: string; }": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "indexSignatureTypesFunction",
+                    parameterName: "inlineSig",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "ObjectWithIndexSignature": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "indexSignatureTypesFunction",
+                    parameterName: "objWithSig",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "ObjectWithPropsAndIndexSignature": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "indexSignatureTypesFunction",
+                    parameterName: "objWithPropsAndSig",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "IntersectionOfMultipleIndexSigs": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "indexSignatureTypesFunction",
+                    parameterName: "intersectionSigs",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            }
+          },
+          objectTypes: {},
+          functions: {
+            "indexSignatureTypesFunction": {
+              description: null,
+              ndcKind: FunctionNdcKind.Procedure,
+              parallelDegree: null,
+              arguments: [
+                {
+                  argumentName: "recordType",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "Record<string, string>",
+                  }
+                },
+                {
+                  argumentName: "inlineSig",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "{ [x: string]: string; }",
+                  }
+                },
+                {
+                  argumentName: "objWithSig",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "ObjectWithIndexSignature",
+                  }
+                },
+                {
+                  argumentName: "objWithPropsAndSig",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "ObjectWithPropsAndIndexSignature",
+                  }
+                },
+                {
+                  argumentName: "intersectionSigs",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "IntersectionOfMultipleIndexSigs",
+                  }
+                },
+              ],
+              resultType: {
+                type: "named",
+                kind: "scalar",
+                name: "String",
+              }
+            },
+          }
+        }
+      })
+    });
+
+    it("invalid", function() {
+      const schema = deriveSchema(require.resolve("./index-signature-types-invalid.ts"));
+
+      assert.deepStrictEqual(schema, {
+        compilerDiagnostics: [],
+        functionIssues: {
+          "indexSignatureTypesFunction": [
+            "The void type is not supported, but one was encountered in function 'indexSignatureTypesFunction' parameter 'recordType', type 'Record<string, void>' type signature index '0' value type",
+            "The undefined type is not supported as a type literal used on its own, but one was encountered in function 'indexSignatureTypesFunction' parameter 'inlineSig', type '{ [x: string]: undefined; }' type signature index '0' value type",
+            "The never type is not supported, but one was encountered in function 'indexSignatureTypesFunction' parameter 'objWithSig', type 'ObjectWithIndexSignature' type signature index '0' value type",
+            "Promise types are not supported, but one was encountered in function 'indexSignatureTypesFunction' parameter 'objWithPropsAndSig', type 'ObjectWithPropsAndIndexSignature' type signature index '0' value type.",
+            "Promise types are not supported, but one was encountered in function 'indexSignatureTypesFunction' parameter 'intersectionSigs', type 'IntersectionOfMultipleIndexSigs' type signature index '1' value type."
+          ]
+        },
+        functionsSchema: {
+          scalarTypes: {
+            "String": { type: "built-in" },
+          },
+          objectTypes: {},
+          functions: {}
+        }
+      })
+    });
+  });
+
+  describe("union types", function() {
+    it("valid", function() {
+      const schema = deriveSchema(require.resolve("./union-types-valid.ts"));
+
+      assert.deepStrictEqual(schema, {
+        compilerDiagnostics: [],
+        functionIssues: {},
+        functionsSchema: {
+          scalarTypes: {
+            "String": { type: "built-in" },
+            "string | number": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "unionTypes",
+                    parameterName: "numberOrString",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "AliasedUnion": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "unionTypes",
+                    parameterName: "aliasedUnion",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "{ prop1: string; } | { prop2: string; }": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "unionTypes",
+                    parameterName: "unionedObjects",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+          },
+          objectTypes: {},
+          functions: {
+            "unionTypes": {
+              description: null,
+              ndcKind: FunctionNdcKind.Procedure,
+              parallelDegree: null,
+              arguments: [
+                {
+                  argumentName: "numberOrString",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "string | number",
+                  }
+                },
+                {
+                  argumentName: "aliasedUnion",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "AliasedUnion",
+                  }
+                },
+                {
+                  argumentName: "unionedObjects",
+                  description: null,
+                  type: {
+                    type: "named",
+                    kind: "scalar",
+                    name: "{ prop1: string; } | { prop2: string; }",
+                  }
+                },
+              ],
+              resultType: {
+                type: "named",
+                kind: "scalar",
+                name: "String",
+              }
+            },
+          }
+        }
+      })
+    });
+
+    it("invalid", function() {
+      const schema = deriveSchema(require.resolve("./union-types-invalid.ts"));
+
+      assert.deepStrictEqual(schema, {
+        compilerDiagnostics: [],
+        functionIssues: {
+          "unionTypes": [
+            "Promise types are not supported, but one was encountered in function 'unionTypes' parameter 'numberOrString', type 'number | Promise<string>' union member index '1'.",
+            "The void type is not supported, but one was encountered in function 'unionTypes' parameter 'aliasedUnion', type 'AliasedUnion' union member index '1'",
+            "The never type is not supported, but one was encountered in function 'unionTypes' parameter 'unionedObjects', type '{ prop1: never; } | { prop2: string; }' union member index '0', type 'unionTypes_arguments_unionedObjects_union_0' property 'prop1'",
+          ]
+        },
+        functionsSchema: {
+          scalarTypes: {
+            "String": { type: "built-in" },
+          },
+          objectTypes: {},
+          functions: {}
+        }
+      })
+    });
+  });
+
+  it("used in object types", function() {
+    const schema = deriveSchema(require.resolve("./used-in-object-types.ts"));
+
+    assert.deepStrictEqual(schema, {
+      compilerDiagnostics: [],
+      functionIssues: {
+        "strictTest": [
+          "The object type 'ObjectWithRelaxedType' uses relaxed types and can only be used by a function marked with @allowrelaxedtypes. It was encountered in function 'strictTest' parameter 'param'"
+        ]
+      },
+      functionsSchema: {
+        scalarTypes: {
+          "String": { type: "built-in" },
+          "string | number": {
+            type: "relaxed-type",
+            usedIn: [
+              [
+                {
+                  segmentType: "FunctionParameter",
+                  functionName: "relaxedTest",
+                  parameterName: "param",
+                },
+                {
+                  segmentType: "ObjectProperty",
+                  typeName: "ObjectWithRelaxedType",
+                  propertyName: "prop",
+                },
+              ]
+            ]
+          },
+        },
+        objectTypes: {
+          "ObjectWithRelaxedType": {
+            description: null,
+            properties: [
+              {
+                propertyName: "prop",
+                description: null,
+                type: {
+                  type: "named",
+                  kind: "scalar",
+                  name: "string | number",
+                }
+              }
+            ],
+            isRelaxedType: true,
+          }
+        },
+        functions: {
+          "relaxedTest": {
+            description: null,
+            ndcKind: FunctionNdcKind.Procedure,
+            parallelDegree: null,
+            arguments: [
+              {
+                argumentName: "param",
+                description: null,
+                type: {
+                  type: "named",
+                  kind: "object",
+                  name: "ObjectWithRelaxedType",
+                }
+              }
+            ],
+            resultType: {
+              type: "named",
+              kind: "scalar",
+              name: "String",
+            }
+          }
+        }
+      }
+    })
+  });
+
+});

--- a/ndc-lambda-sdk/test/inference/relaxed-types/tuple-types-invalid.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/tuple-types-invalid.ts
@@ -1,0 +1,10 @@
+type Tuple<A,B> = [A, B]
+
+/** @allowrelaxedtypes */
+export function tupleFunction(
+  tuple1: [void],
+  tuple2: [string, never],
+  tupleAlias: Tuple<number, Promise<boolean>>
+): string {
+  return "wow";
+}

--- a/ndc-lambda-sdk/test/inference/relaxed-types/tuple-types-valid.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/tuple-types-valid.ts
@@ -1,0 +1,10 @@
+type Tuple<A,B> = [A, B]
+
+/** @allowrelaxedtypes */
+export function tupleFunction(
+  tuple1: [string],
+  tuple2: [string, number],
+  tupleAlias: Tuple<number, boolean>
+): string {
+  return "wow";
+}

--- a/ndc-lambda-sdk/test/inference/relaxed-types/union-types-invalid.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/union-types-invalid.ts
@@ -1,0 +1,10 @@
+type AliasedUnion = string | void;
+
+/** @allowrelaxedtypes */
+export function unionTypes(
+  numberOrString: number | Promise<string>,
+  aliasedUnion: AliasedUnion,
+  unionedObjects: { prop1: never } | { prop2: string }
+): string {
+  return ""
+}

--- a/ndc-lambda-sdk/test/inference/relaxed-types/union-types-valid.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/union-types-valid.ts
@@ -1,0 +1,10 @@
+type AliasedUnion = string | boolean;
+
+/** @allowrelaxedtypes */
+export function unionTypes(
+  numberOrString: number | string,
+  aliasedUnion: AliasedUnion,
+  unionedObjects: { prop1: string } | { prop2: string }
+): string {
+  return ""
+}

--- a/ndc-lambda-sdk/test/inference/relaxed-types/unknown.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/unknown.ts
@@ -1,0 +1,4 @@
+/** @allowrelaxedtypes */
+export function unknownFunction(test: unknown): string {
+  return "wow";
+}

--- a/ndc-lambda-sdk/test/inference/relaxed-types/used-in-object-types.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/used-in-object-types.ts
@@ -1,0 +1,12 @@
+type ObjectWithRelaxedType = {
+  prop: string | number
+}
+
+/** @allowrelaxedtypes */
+export function relaxedTest(param: ObjectWithRelaxedType): string {
+  return ""
+}
+
+export function strictTest(param: ObjectWithRelaxedType): string {
+  return ""
+}

--- a/ndc-lambda-sdk/test/inference/type-descriptions/type-descriptions.test.ts
+++ b/ndc-lambda-sdk/test/inference/type-descriptions/type-descriptions.test.ts
@@ -35,7 +35,7 @@ describe("type descriptions", function() {
           },
         },
         scalarTypes: {
-          String: {},
+          String: { type: "built-in" },
         },
         objectTypes: {},
       }
@@ -100,7 +100,7 @@ describe("type descriptions", function() {
           },
         },
         scalarTypes: {
-          String: {},
+          String: { type: "built-in" },
         },
         objectTypes: {
           "MyObjType": {
@@ -115,7 +115,8 @@ describe("type descriptions", function() {
                   name: "String"
                 }
               }
-            ]
+            ],
+            isRelaxedType: false,
           },
           "IInterface": {
             description: "What a great interface",
@@ -129,7 +130,8 @@ describe("type descriptions", function() {
                   name: "String"
                 }
               }
-            ]
+            ],
+            isRelaxedType: false,
           },
           "IGenericInterface<string>": {
             description: "The most generic of interfaces",
@@ -143,7 +145,8 @@ describe("type descriptions", function() {
                   name: "String"
                 }
               }
-            ]
+            ],
+            isRelaxedType: false,
           },
           "IntersectionType": {
             description: "Just smashing things together over here",
@@ -166,7 +169,8 @@ describe("type descriptions", function() {
                   name: "String"
                 }
               }
-            ]
+            ],
+            isRelaxedType: false,
           }
         },
       }

--- a/ndc-lambda-sdk/test/inference/unsupported-types/map-types.ts
+++ b/ndc-lambda-sdk/test/inference/unsupported-types/map-types.ts
@@ -21,3 +21,17 @@ type ObjectWithPropsAndIndexSignature = {
 export function objectWithPropsAndIndexSignatureType(param: ObjectWithPropsAndIndexSignature): string {
   return "";
 }
+
+type MyType1 = {
+  [index: number]: string;
+};
+
+type MyType2 = {
+  [key: string]: number;
+};
+
+type IntersectionOfMultipleIndexSigs = MyType1 & MyType2
+
+export function objectWithMultipleIndexSignaturesType(param: IntersectionOfMultipleIndexSigs): string {
+  return "";
+}

--- a/ndc-lambda-sdk/test/inference/unsupported-types/unsupported-types.test.ts
+++ b/ndc-lambda-sdk/test/inference/unsupported-types/unsupported-types.test.ts
@@ -15,7 +15,7 @@ describe("unsupported types", function() {
       },
       functionsSchema: {
         scalarTypes: {
-          String: {},
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {}
@@ -53,7 +53,7 @@ describe("unsupported types", function() {
       },
       functionsSchema: {
         scalarTypes: {
-          String: {}
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {}
@@ -73,7 +73,7 @@ describe("unsupported types", function() {
       },
       functionsSchema: {
         scalarTypes: {
-          String: {}
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {}
@@ -93,7 +93,7 @@ describe("unsupported types", function() {
       },
       functionsSchema: {
         scalarTypes: {
-          String: {}
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {}
@@ -113,7 +113,7 @@ describe("unsupported types", function() {
       },
       functionsSchema: {
         scalarTypes: {
-          String: {}
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {}
@@ -139,7 +139,7 @@ describe("unsupported types", function() {
       },
       functionsSchema: {
         scalarTypes: {
-          String: {}
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {}
@@ -184,7 +184,7 @@ describe("unsupported types", function() {
       },
       functionsSchema: {
         scalarTypes: {
-          String: {}
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {}
@@ -210,7 +210,7 @@ describe("unsupported types", function() {
       },
       functionsSchema: {
         scalarTypes: {
-          String: {}
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {}
@@ -232,7 +232,7 @@ describe("unsupported types", function() {
       },
       functionsSchema: {
         scalarTypes: {
-          String: {}
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {}
@@ -258,10 +258,13 @@ describe("unsupported types", function() {
         "objectWithPropsAndIndexSignatureType": [
           "Types with index signatures are not supported, but one was encountered in function 'objectWithPropsAndIndexSignatureType' parameter 'param' (type: ObjectWithPropsAndIndexSignature)",
         ],
+        "objectWithMultipleIndexSignaturesType": [
+          "Types with index signatures are not supported, but one was encountered in function 'objectWithMultipleIndexSignaturesType' parameter 'param' (type: IntersectionOfMultipleIndexSigs)"
+        ],
       },
       functionsSchema: {
         scalarTypes: {
-          String: {}
+          String: { type: "built-in" },
         },
         objectTypes: {},
         functions: {}

--- a/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
+++ b/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
@@ -87,11 +87,12 @@ describe("ndc schema", function() {
               },
             },
           ],
+          isRelaxedType: false,
         },
       },
       scalarTypes: {
-        String: {},
-        test_arguments_unionWithNull: {},
+        String: { type: "built-in" },
+        test_arguments_unionWithNull: { type: "built-in" },
       },
     };
 


### PR DESCRIPTION
This PR adds support for "relaxed types". "Relaxed types" are types that are otherwise unsupported (ie. we don't know how to make an NDC schema for them (yet)), but instead of being rejected are instead converted into opaque scalar types. To opt into using relaxed types, one must apply the `@allowrelaxedtypes` JSDoc tag to the function that will be using the unsupported types.

Please see the readme for more information.

JIRA: [NDC-389](https://hasurahq.atlassian.net/browse/NDC-389)

## Solution Design
The `ScalarTypeDefinition` and `ObjectTypeDefinition` (in `schema.ts`) now have markers on them that describe whether or not the type is a relaxed type. A relaxed type `ScalarTypeDefinition` represents an unsupported type that has been munged into a opaque scalar, and a relaxed type `ObjectTypeDefinition` is simply an object type that uses a relaxed type somewhere in its properties.

All the existing `TypeDefinition` subtypes got renamed to `TypeReference` (eg `ArrayTypeDefinition` -> `ArrayTypeReference`), because they aren't really "definitions", they're actually just references to types defined elsewhere.

`inference.ts`'s `deriveSchemaTypeForTsType` function has been refactored significantly to extract out all the previously rejected types that are now allowed in relaxed type mode into separate functions which validate them and emit scalar types.

For unsupported types that are composite types (ie are made up of other types, for example `Record<string, number>`), they will only be allowed to be used as a relaxed type if the types they compose are allowed as supported or relaxed types. This prevents users from using relaxed types to allow nonsensical types such as `Record<string, void>`.

New unit tests have been added to cover all the permutations of relaxed types in `test/inference/relaxed-types`.

[NDC-389]: https://hasurahq.atlassian.net/browse/NDC-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ