### PR TITLE
Update to NDC TypeScript SDK v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ This changelog documents the changes between release versions.
 ## main
 Changes to be included in the next upcoming release
 
-- Support for NDC Spec v0.1.0-rc.15 via the NDC TypeScript SDK v3.0.0. This is a breaking change and must be used with the latest Hasura engine.
+- Support for NDC Spec v0.1.0-rc.15 via the NDC TypeScript SDK v4.0.0 ([#8](https://github.com/hasura/ndc-nodejs-lambda/pull/8), [#10](https://github.com/hasura/ndc-nodejs-lambda/pull/11)). This is a breaking change and must be used with the latest Hasura engine.
   - Support for nested object/array selection
   - New function calling convention that relies on nested object queries
   - New mutation request/response format
+  - [New names](https://github.com/hasura/ndc-sdk-typescript/releases/tag/v4.0.0) for configuration environment variables
+  - The default port is now 8080 instead of 8100
 
 ## v0.14.0
 - Support for "relaxed types" ([#10](https://github.com/hasura/ndc-nodejs-lambda/pull/10))

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ COPY /docker /scripts
 COPY /functions /functions
 RUN /scripts/package-restore.sh
 
-EXPOSE 8100
+EXPOSE 8080
 
 CMD [ "sh", "/scripts/start.sh" ]

--- a/ndc-lambda-sdk/bin/index.js
+++ b/ndc-lambda-sdk/bin/index.js
@@ -12,8 +12,7 @@ const { makeCommand } = require("../dist/src/cmdline")
 // We need to get at the user's specified typescript functions file path early here in this shim
 // so that we can search for their tsconfig in order to configure ts-node/ts-node-dev properly
 const program = makeCommand({
-  serveAction: () => {},
-  configurationServeAction: () => {}
+  serveAction: () => {}
 })
 program.parse();
 

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hasura/ndc-sdk-typescript": "^3.0.0",
-        "@json-schema-tools/meta-schema": "^1.7.0",
+        "@hasura/ndc-sdk-typescript": "^4.0.0",
         "@tsconfig/node18": "^18.2.2",
         "commander": "^11.1.0",
         "cross-spawn": "^7.0.3",
@@ -74,9 +73,9 @@
       }
     },
     "node_modules/@hasura/ndc-sdk-typescript": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-3.0.0.tgz",
-      "integrity": "sha512-Y4CuobtWdWSh5CCetyPzflyo1vISmZJenZ6DELRTlHHt+wwr2lCCKXb2rGRg7rbDglzG3KE2LnoER16LuGnoiw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-4.0.0.tgz",
+      "integrity": "sha512-XXikE7g0sq2RjRsSgOJ3dudDRe1DR+OxOWUulEK309ft9iURpcj7jG3UuUXWyhQClQJ9RWj2rhCEiX1Op0+CDw==",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
         "commander": "^11.0.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -30,8 +30,7 @@
     "url": "git+https://github.com/hasura/ndc-nodejs-lambda.git"
   },
   "dependencies": {
-    "@hasura/ndc-sdk-typescript": "^3.0.0",
-    "@json-schema-tools/meta-schema": "^1.7.0",
+    "@hasura/ndc-sdk-typescript": "^4.0.0",
     "@tsconfig/node18": "^18.2.2",
     "commander": "^11.1.0",
     "cross-spawn": "^7.0.3",

--- a/ndc-lambda-sdk/src/cmdline.ts
+++ b/ndc-lambda-sdk/src/cmdline.ts
@@ -9,7 +9,6 @@ export type HostOptions = {
 
 export interface CommandActions {
   serveAction(hostOpts: HostOptions, serverOpts: sdk.ServerOptions): Promise<void> | void
-  configurationServeAction(hostOpts: HostOptions, serverOpts: sdk.ConfigurationServerOptions): Promise<void> | void
 }
 
 export function makeCommand(commandActions: CommandActions): Command {
@@ -23,12 +22,6 @@ export function makeCommand(commandActions: CommandActions): Command {
     return commandActions.serveAction(hostOpts, serverOptions);
   })
 
-  const configurationServeCommand = sdk.getServeConfigurationCommand();
-  configurationServeCommand.commands.find(c => c.name() === "serve")?.action((serverOptions: sdk.ConfigurationServerOptions, command: Command) => {
-    const hostOpts: HostOptions = hostCommand.opts();
-    return commandActions.configurationServeAction(hostOpts, serverOptions);
-  });
-
   const hostCommand = program
     .command("host")
     .addOption(
@@ -37,8 +30,7 @@ export function makeCommand(commandActions: CommandActions): Command {
         .env("WATCH")
     )
     .requiredOption("-f, --functions <filepath>", "path to your TypeScript functions file")
-    .addCommand(serveCommand)
-    .addCommand(configurationServeCommand);
+    .addCommand(serveCommand);
 
   return program;
 }

--- a/ndc-lambda-sdk/src/connector.ts
+++ b/ndc-lambda-sdk/src/connector.ts
@@ -1,11 +1,9 @@
 import * as sdk from "@hasura/ndc-sdk-typescript";
-import { JSONSchemaObject } from "@json-schema-tools/meta-schema";
 import path from "node:path"
 import { FunctionsSchema, getNdcSchema, printRelaxedTypesWarning } from "./schema";
 import { deriveSchema, printCompilerDiagnostics, printFunctionIssues } from "./inference";
 import { RuntimeFunctions, executeMutation, executeQuery } from "./execution";
 
-export type RawConfiguration = {};
 export type Configuration = {
   functionsSchema: FunctionsSchema
 };
@@ -14,34 +12,16 @@ export type State = {
   runtimeFunctions: RuntimeFunctions
 }
 
-export const RAW_CONFIGURATION_SCHEMA: JSONSchemaObject = {
-  description: 'NodeJS Lambda SDK Connector Configuration',
-  type: 'object',
-  required: [],
-  properties: {}
-};
-
 export type ConnectorOptions = {
   functionsFilePath: string
 }
 
-export function createConnector(options: ConnectorOptions): sdk.Connector<RawConfiguration, Configuration, State> {
+export function createConnector(options: ConnectorOptions): sdk.Connector<Configuration, State> {
   const functionsFilePath = path.resolve(options.functionsFilePath);
 
-  const connector: sdk.Connector<RawConfiguration, Configuration, State> = {
-    getRawConfigurationSchema: function (): JSONSchemaObject {
-      return RAW_CONFIGURATION_SCHEMA;
-    },
+  const connector: sdk.Connector<Configuration, State> = {
 
-    makeEmptyConfiguration: function (): RawConfiguration {
-      return {};
-    },
-
-    updateConfiguration: async function (rawConfiguration: RawConfiguration): Promise<RawConfiguration> {
-      return {};
-    },
-
-    validateRawConfiguration: async function (rawConfiguration: RawConfiguration): Promise<Configuration> {
+    parseConfiguration: async function (configurationDir: string): Promise<Configuration> {
       const schemaResults = deriveSchema(functionsFilePath);
       printCompilerDiagnostics(schemaResults.compilerDiagnostics);
       printFunctionIssues(schemaResults.functionIssues);

--- a/ndc-lambda-sdk/src/host.ts
+++ b/ndc-lambda-sdk/src/host.ts
@@ -4,7 +4,6 @@ import { makeCommand } from "./cmdline";
 
 const program = makeCommand({
   serveAction: (hostOpts, serveOpts) => sdk.startServer(createConnector({functionsFilePath: hostOpts.functions}), serveOpts),
-  configurationServeAction: (hostOpts, serveOpts) => sdk.startConfigurationServer(createConnector({functionsFilePath: hostOpts.functions}), serveOpts),
 });
 
 program.parseAsync().catch(err => {


### PR DESCRIPTION
This SDK update brings support for the new deployment spec (see [SDK v4 release notes](https://github.com/hasura/ndc-sdk-typescript/releases/tag/v4.0.0)).