### PR TITLE
Update to TS SDK v1.4.0, add additional tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog documents the changes between release versions.
 ## Unreleased
 Changes to be included in the next upcoming v0 release
 
+## v0.16.0
+- Updated to [NDC TypeScript SDK v1.4.0](https://github.com/hasura/ndc-sdk-typescript/releases/tag/v1.4.0) to include OpenTelemetry improvements. Traced spans should now appear in the Hasura Console
+- Additional OpenTelemetry trace spans covering work done around function invocations
+
 ## v0.15.0
 - OpenTelemetry support added via support for NDC TypeScript SDK v1.3.0 ([#12](https://github.com/hasura/ndc-nodejs-lambda/pull/12))
 

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-lambda-sdk",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hasura/ndc-sdk-typescript": "^1.3.0",
+        "@hasura/ndc-sdk-typescript": "^1.4.0",
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@tsconfig/node18": "^18.2.2",
         "commander": "^11.1.0",
@@ -141,14 +141,15 @@
       }
     },
     "node_modules/@hasura/ndc-sdk-typescript": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-1.3.0.tgz",
-      "integrity": "sha512-nVNJTEjofEqAE72y/FENFkFwIlXZyZoHy9rc5mr8Q4crphj9IWzRmlnwrcONEQZv3UOAvjd9wxyxbqFH5ydZmg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-1.4.0.tgz",
+      "integrity": "sha512-aljnpmK0l0gUdLXh0On+GBw+jxHr+dpnHLe/XhxnLaZHR6VC4Uro8GIDJ2r7fPH0cvogG/URlNPiw1frgVa5IA==",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.48.0",
         "@opentelemetry/instrumentation-fastify": "^0.33.0",
+        "@opentelemetry/instrumentation-fetch": "^0.48.0",
         "@opentelemetry/instrumentation-http": "^0.48.0",
         "@opentelemetry/instrumentation-pino": "^0.35.0",
         "@opentelemetry/resources": "^1.21.0",
@@ -377,6 +378,23 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-fetch": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.48.0.tgz",
+      "integrity": "sha512-y4Zw9VeUUMaowg3aXYZXcaUJQ7IKfpR6sjClrAQOJwWG8LYFpM6NIRSoAeJv/ShfxWWCPWC0P4zgXcKRqpURFQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-http": {
       "version": "0.48.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.48.0.tgz",
@@ -602,6 +620,22 @@
         "@opentelemetry/propagator-jaeger": "1.21.0",
         "@opentelemetry/sdk-trace-base": "1.21.0",
         "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.21.0.tgz",
+      "integrity": "sha512-MxkmY/UNXkDiZj7JUu5T7wWt8Ai4NJEwSjGoQQ9YLvgLUIivvaIo9Mne+Q+KLOUG2v/uhivz3qzxbCODVa0c1A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "SDK that can automatically expose TypeScript functions as Hasura NDC functions/procedures",
   "author": "Hasura",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
     "url": "git+https://github.com/hasura/ndc-nodejs-lambda.git"
   },
   "dependencies": {
-    "@hasura/ndc-sdk-typescript": "^1.3.0",
+    "@hasura/ndc-sdk-typescript": "^1.4.0",
     "@json-schema-tools/meta-schema": "^1.7.0",
     "@tsconfig/node18": "^18.2.2",
     "commander": "^11.1.0",

--- a/yeoman-generator/package-lock.json
+++ b/yeoman-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generator-hasura-ndc-nodejs-lambda",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generator-hasura-ndc-nodejs-lambda",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
         "pacote": "^17.0.5",
         "semver": "^7.5.4",

--- a/yeoman-generator/package.json
+++ b/yeoman-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-hasura-ndc-nodejs-lambda",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Yeoman generator for Hasura DDN ndc-nodejs-lambda connectors",
   "files": [
     "generators"


### PR DESCRIPTION
This PR updates the TS SDK to [v1.4.0](https://github.com/hasura/ndc-sdk-typescript/releases/tag/v1.4.0) to bring in OpenTelemetry improvements.

It also backports the additional tracing spans added in #13.

The version has been bumped to v0.16.0.