### PR TITLE
Add tracing documentation and export tracing functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog documents the changes between release versions.
 Changes to be included in the next upcoming release
 
 - Updated to [NDC TypeScript SDK v4.2.0](https://github.com/hasura/ndc-sdk-typescript/releases/tag/v4.2.0) to include OpenTelemetry improvements. Traced spans should now appear in the Hasura Console
+- Custom OpenTelemetry trace spans can now be emitted by creating an OpenTelemetry tracer and using it with `sdk.withActiveSpan` ([#16](https://github.com/hasura/ndc-nodejs-lambda/pull/16))
 
 ## [1.0.0] - 2024-02-22
 ### ndc-lambda-sdk

--- a/ndc-lambda-sdk/src/sdk.ts
+++ b/ndc-lambda-sdk/src/sdk.ts
@@ -1,3 +1,4 @@
 export { JSONValue } from "./schema";
 export { ConnectorError, BadRequest, Forbidden, Conflict, UnprocessableContent, InternalServerError, NotSupported, BadGateway } from "@hasura/ndc-sdk-typescript";
+export { withActiveSpan, USER_VISIBLE_SPAN_ATTRIBUTE } from "@hasura/ndc-sdk-typescript/instrumentation"
 export { ErrorDetails, getErrorDetails } from "./execution";


### PR DESCRIPTION
This PR adds documentation about tracing and how to add custom tracing spans. It exports `withActiveSpan` from the TS SDK to make this easier for the user to do.

See changes to the readme for more information.