### PR TITLE
Block usage of enum types but allow them as relaxed types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This changelog documents the changes between release versions.
 > Hasura DDN Alpha users should use 0.x versions of the `ndc-lambda-sdk`. v1.x versions of the `ndc-lambda-sdk` support the forthcoming Hasura DDN Beta.
 
 ## [Unreleased]
-Changes to be included in the next upcoming release
+- Improved error messages when unsupported enum types or unions of literal types are found, and allow these types to be used in relaxed types mode ([#17](https://github.com/hasura/ndc-nodejs-lambda/pull/17))
 
 ## [1.1.0] - 2024-02-26
 - Updated to [NDC TypeScript SDK v4.2.0](https://github.com/hasura/ndc-sdk-typescript/releases/tag/v4.2.0) to include OpenTelemetry improvements. Traced spans should now appear in the Hasura Console

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog documents the changes between release versions.
 > Hasura DDN Alpha users should use 0.x versions of the `ndc-lambda-sdk`. v1.x versions of the `ndc-lambda-sdk` support the forthcoming Hasura DDN Beta.
 
 ## [Unreleased]
+Changes to be included in the next upcoming release
+
 - Improved error messages when unsupported enum types or unions of literal types are found, and allow these types to be used in relaxed types mode ([#17](https://github.com/hasura/ndc-nodejs-lambda/pull/17))
 
 ## [1.1.0] - 2024-02-26

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ These types are unsupported as function parameter types or return types for func
 * [Function types](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions) - function types can't be accepted as arguments or returned as values
 * [`void`](https://www.typescriptlang.org/docs/handbook/2/functions.html#void), [`object`](https://www.typescriptlang.org/docs/handbook/2/functions.html#object), [`unknown`](https://www.typescriptlang.org/docs/handbook/2/functions.html#unknown), [`never`](https://www.typescriptlang.org/docs/handbook/2/functions.html#never), [`any`](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#any) types - to accept and return arbitrary JSON, use `sdk.JSONValue` instead
 * `null` and `undefined` - unless used in a union with a single other type
+* [Enum types](https://www.typescriptlang.org/docs/handbook/enums.html)
 
 ### Relaxed Types
 "Relaxed types" are types that are otherwise unsupported, but instead of being rejected are instead converted into opaque custom scalar types. These scalar types are entirely unvalidated when used as input (ie. the caller of the function can send arbitrary JSON values), making it incumbent on the function itself to ensure the incoming value for that relaxed type actually matches its type. Because relaxed types are represented as custom scalar types, in GraphQL you will be unable to select into the type, if it is an object, and will only be able to select the whole thing.
@@ -161,6 +162,7 @@ The following unsupported types are allowed when using relaxed types, and will b
 * Tuple types
 * Types with index signatures
 * The `any` and `unknown` types
+* Enum types
 
 Here's an example of a function that uses some relaxed types:
 

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hasura/ndc-sdk-typescript": "^4.2.0",
+        "@hasura/ndc-sdk-typescript": "^4.2.1",
         "@tsconfig/node18": "^18.2.2",
         "commander": "^11.1.0",
         "cross-spawn": "^7.0.3",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@hasura/ndc-sdk-typescript": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-4.2.0.tgz",
-      "integrity": "sha512-MQd3KsNBFN+3rDE8ngJEyqPDXEmUupFmvDqgpDZy+4sIVyKR/7xTc/ZtsAcSp58FB4ZU6njngU55pdlTsBa+dg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-4.2.1.tgz",
+      "integrity": "sha512-NbrbHTcCZsgG8EfVxfHsdwDCc6i+SJ40HqiOJau9p/RhDtif2HH7zoAa+9V2Bnyn2rPPYOFdZM46iHagOCei6Q==",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@opentelemetry/api": "^1.7.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -30,7 +30,7 @@
     "url": "git+https://github.com/hasura/ndc-nodejs-lambda.git"
   },
   "dependencies": {
-    "@hasura/ndc-sdk-typescript": "^4.2.0",
+    "@hasura/ndc-sdk-typescript": "^4.2.1",
     "@tsconfig/node18": "^18.2.2",
     "commander": "^11.1.0",
     "cross-spawn": "^7.0.3",

--- a/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
+++ b/ndc-lambda-sdk/test/inference/basic-inference/basic-inference.test.ts
@@ -925,7 +925,17 @@ describe("basic inference", function() {
                   name: BuiltInScalarTypeName.Float,
                   literalValue: 0,
                 }
-              }
+              },
+              {
+                propertyName: "singleItemEnum",
+                description: null,
+                type: {
+                  type: "named",
+                  kind: "scalar",
+                  name: BuiltInScalarTypeName.String,
+                  literalValue: "SingleItem",
+                }
+              },
             ],
             isRelaxedType: false,
           }

--- a/ndc-lambda-sdk/test/inference/basic-inference/literal-types.ts
+++ b/ndc-lambda-sdk/test/inference/basic-inference/literal-types.ts
@@ -5,14 +5,22 @@ type LiteralProps = {
   literalBigInt: -123n,
   literalStringEnum: StringEnum.EnumItem
   literalNumericEnum: NumericEnum.EnumItem
+  singleItemEnum: SingleItemEnum
 }
 
 enum StringEnum {
-  EnumItem = "EnumItem"
+  EnumItem = "EnumItem",
+  SecondEnumItem = "SecondEnumItem"
 }
 
 enum NumericEnum {
-  EnumItem
+  EnumItem,
+  SecondEnumItem
+}
+
+// Single item enums are simplified by the compiler to a literal type
+enum SingleItemEnum {
+  SingleItem = "SingleItem"
 }
 
 export function literalTypes(): LiteralProps {
@@ -23,5 +31,6 @@ export function literalTypes(): LiteralProps {
     literalBigInt: -123n,
     literalStringEnum: StringEnum.EnumItem,
     literalNumericEnum: NumericEnum.EnumItem,
+    singleItemEnum: SingleItemEnum.SingleItem
   };
 }

--- a/ndc-lambda-sdk/test/inference/relaxed-types/enum-types-invalid.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/enum-types-invalid.ts
@@ -1,0 +1,12 @@
+type StringLiteralEnum = "1st" | "2nd" | Promise<"3rd">
+
+/**
+ * @readonly
+ * @allowrelaxedtypes
+ */
+export function enumTypesFunction(
+  stringLiteralEnum: StringLiteralEnum,
+  inlineStringLiteralEnum: "1st" | "2nd" | void,
+): string {
+  return ""
+}

--- a/ndc-lambda-sdk/test/inference/relaxed-types/enum-types-valid.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/enum-types-valid.ts
@@ -1,0 +1,70 @@
+enum StringEnum {
+  First = "First",
+  Second = "Second"
+}
+
+enum NumberEnum {
+  First = 1,
+  Second = 2
+}
+
+enum MixedEnum {
+  Dog = "Dog",
+  Cat = "Cat",
+  Other = 1234,
+}
+
+const enum ConstEnum {
+  First = "first",
+  Second = "second",
+}
+
+enum ComputedEnum {
+  Gross = "Gross".length,
+  Foul = "Foul".length
+}
+
+enum ComputedSingleItemEnum {
+  Single = "Single".length
+}
+
+type StringLiteralEnum = "1st" | "2nd"
+
+type NumberLiteralEnum = 0 | 1 | 2
+
+type MixedLiteralEnum = true | false | 0 | 1 | "1st" | "2nd"
+
+const ConstObjEnumVal = {
+  Plant: "plant",
+  Animal: "animal"
+} as const;
+
+type ConstObjEnum = typeof ConstObjEnumVal[keyof typeof ConstObjEnumVal]
+
+/**
+ * @readonly
+ * @allowrelaxedtypes
+ */
+export function enumTypesFunction(
+  stringEnum: StringEnum,
+  numberEnum: NumberEnum,
+  mixedEnum: MixedEnum,
+  constEnum: ConstEnum,
+  computedEnum: ComputedEnum,
+  computedSingleItemEnum: ComputedSingleItemEnum,
+  stringLiteralEnum: StringLiteralEnum,
+  stringLiteralEnumMaybe: StringLiteralEnum | undefined,
+  inlineStringLiteralEnum: "1st" | "2nd",
+  inlineStringLiteralEnumMaybe: "1st" | "2nd" | null,
+  numberLiteralEnum: NumberLiteralEnum,
+  numberLiteralEnumMaybe: NumberLiteralEnum | null,
+  inlineNumberLiteralEnum: 0 | 1 | 2,
+  inlineNumberLiteralEnumMaybe: 0 | 1 | 2 | undefined,
+  mixedLiteralEnum: MixedLiteralEnum,
+  mixedLiteralEnumMaybe: MixedLiteralEnum | undefined | null,
+  inlineMixedLiteralEnum: true | 1 | "first",
+  inlineMixedLiteralEnumMaybe: true | 1 | "first" | undefined | null,
+  constObjEnum: ConstObjEnum,
+): string {
+  return ""
+}

--- a/ndc-lambda-sdk/test/inference/relaxed-types/relaxed-types.test.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/relaxed-types.test.ts
@@ -924,7 +924,7 @@ describe("relaxed types", function() {
       })
     });
 
-    it("invaliddd", function() {
+    it("invalid", function() {
       const schema = deriveSchema(require.resolve("./enum-types-invalid.ts"));
 
       assert.deepStrictEqual(schema, {

--- a/ndc-lambda-sdk/test/inference/relaxed-types/relaxed-types.test.ts
+++ b/ndc-lambda-sdk/test/inference/relaxed-types/relaxed-types.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "mocha";
 import { assert } from "chai";
 import { deriveSchema } from "../../../src/inference";
-import { FunctionNdcKind } from "../../../src/schema";
+import { FunctionNdcKind, NullOrUndefinability } from "../../../src/schema";
 
 describe("relaxed types", function() {
   it("any", function() {
@@ -488,6 +488,451 @@ describe("relaxed types", function() {
             "Promise types are not supported, but one was encountered in function 'unionTypes' parameter 'numberOrString', type 'number | Promise<string>' union member index '1'.",
             "The void type is not supported, but one was encountered in function 'unionTypes' parameter 'aliasedUnion', type 'AliasedUnion' union member index '1'",
             "The never type is not supported, but one was encountered in function 'unionTypes' parameter 'unionedObjects', type '{ prop1: never; } | { prop2: string; }' union member index '0', type 'unionTypes_arguments_unionedObjects_union_0' property 'prop1'",
+          ]
+        },
+        functionsSchema: {
+          scalarTypes: {
+            "String": { type: "built-in" },
+          },
+          objectTypes: {},
+          functions: {}
+        }
+      })
+    });
+  });
+
+  describe("enum types", function() {
+    it("valid", function() {
+      const schema = deriveSchema(require.resolve("./enum-types-valid.ts"));
+
+      assert.deepStrictEqual(schema, {
+        compilerDiagnostics: [],
+        functionIssues: {},
+        functionsSchema: {
+          scalarTypes: {
+            "\"1st\" | \"2nd\"": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "inlineStringLiteralEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "inlineStringLiteralEnumMaybe",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+              ]
+            },
+            "0 | 1 | 2": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "inlineNumberLiteralEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "inlineNumberLiteralEnumMaybe",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+              ]
+            },
+            "ComputedEnum": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "computedEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "ComputedSingleItemEnum": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "computedSingleItemEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "ConstEnum": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "constEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "ConstObjEnum": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "constObjEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+              ]
+            },
+            "MixedEnum": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "mixedEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "MixedLiteralEnum": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "mixedLiteralEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "mixedLiteralEnumMaybe",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+              ]
+            },
+            "NumberEnum": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "numberEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "NumberLiteralEnum": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "numberLiteralEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "numberLiteralEnumMaybe",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+              ]
+            },
+            "String": { type: "built-in" },
+            "StringEnum": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "stringEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ]
+              ]
+            },
+            "StringLiteralEnum": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "stringLiteralEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "stringLiteralEnumMaybe",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+              ]
+            },
+            "true | 1 | \"first\"": {
+              type: "relaxed-type",
+              usedIn: [
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "inlineMixedLiteralEnum",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+                [
+                  {
+                    functionName: "enumTypesFunction",
+                    parameterName: "inlineMixedLiteralEnumMaybe",
+                    segmentType: "FunctionParameter",
+                  }
+                ],
+              ]
+            },
+          },
+          objectTypes: {},
+          functions: {
+            "enumTypesFunction": {
+              description: null,
+              ndcKind: FunctionNdcKind.Function,
+              parallelDegree: null,
+              arguments: [
+                {
+                  argumentName: "stringEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "StringEnum",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "numberEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "NumberEnum",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "mixedEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "MixedEnum",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "constEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "ConstEnum",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "computedEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "ComputedEnum",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "computedSingleItemEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "ComputedSingleItemEnum",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "stringLiteralEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "StringLiteralEnum",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "stringLiteralEnumMaybe",
+                  description: null,
+                  type: {
+                    type: "nullable",
+                    nullOrUndefinability: NullOrUndefinability.AcceptsUndefinedOnly,
+                    underlyingType: {
+                      kind: "scalar",
+                      name: "StringLiteralEnum",
+                      type: "named",
+                    },
+                  },
+                },
+                {
+                  argumentName: "inlineStringLiteralEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "\"1st\" | \"2nd\"",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "inlineStringLiteralEnumMaybe",
+                  description: null,
+                  type: {
+                    type: "nullable",
+                    nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
+                    underlyingType: {
+                      kind: "scalar",
+                      name: "\"1st\" | \"2nd\"",
+                      type: "named",
+                    },
+                  },
+                },
+                {
+                  argumentName: "numberLiteralEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "NumberLiteralEnum",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "numberLiteralEnumMaybe",
+                  description: null,
+                  type: {
+                    nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
+                    type: "nullable",
+                    underlyingType: {
+                      kind: "scalar",
+                      name: "NumberLiteralEnum",
+                      type: "named",
+                    },
+                  },
+                },
+                {
+                  argumentName: "inlineNumberLiteralEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "0 | 1 | 2",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "inlineNumberLiteralEnumMaybe",
+                  description: null,
+                  type: {
+                    nullOrUndefinability: NullOrUndefinability.AcceptsUndefinedOnly,
+                    type: "nullable",
+                    underlyingType: {
+                      kind: "scalar",
+                      name: "0 | 1 | 2",
+                      type: "named",
+                    },
+                  },
+                },
+                {
+                  argumentName: "mixedLiteralEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "MixedLiteralEnum",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "mixedLiteralEnumMaybe",
+                  description: null,
+                  type: {
+                    nullOrUndefinability: NullOrUndefinability.AcceptsEither,
+                    type: "nullable",
+                    underlyingType: {
+                      kind: "scalar",
+                      name: "MixedLiteralEnum",
+                      type: "named",
+                    },
+                  },
+                },
+                {
+                  argumentName: "inlineMixedLiteralEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "true | 1 | \"first\"",
+                    type: "named",
+                  },
+                },
+                {
+                  argumentName: "inlineMixedLiteralEnumMaybe",
+                  description: null,
+                  type: {
+                    nullOrUndefinability: NullOrUndefinability.AcceptsEither,
+                    type: "nullable",
+                    underlyingType: {
+                      kind: "scalar",
+                      name: "true | 1 | \"first\"",
+                      type: "named",
+                    },
+                  },
+                },
+                {
+                  argumentName: "constObjEnum",
+                  description: null,
+                  type: {
+                    kind: "scalar",
+                    name: "ConstObjEnum",
+                    type: "named",
+                  },
+                },
+              ],
+              resultType: {
+                type: "named",
+                kind: "scalar",
+                name: "String",
+              }
+            },
+          }
+        }
+      })
+    });
+
+    it("invaliddd", function() {
+      const schema = deriveSchema(require.resolve("./enum-types-invalid.ts"));
+
+      assert.deepStrictEqual(schema, {
+        compilerDiagnostics: [],
+        functionIssues: {
+          "enumTypesFunction": [
+            "Promise types are not supported, but one was encountered in function 'enumTypesFunction' parameter 'stringLiteralEnum', type 'StringLiteralEnum' union member index '0'.",
+            "The void type is not supported, but one was encountered in function 'enumTypesFunction' parameter 'inlineStringLiteralEnum', type 'void | \"1st\" | \"2nd\"' union member index '0'",
           ]
         },
         functionsSchema: {

--- a/ndc-lambda-sdk/test/inference/unsupported-types/enum-types.ts
+++ b/ndc-lambda-sdk/test/inference/unsupported-types/enum-types.ts
@@ -1,0 +1,75 @@
+enum StringEnum {
+  First = "First",
+  Second = "Second"
+}
+
+enum NumberEnum {
+  First = 1,
+  Second = 2
+}
+
+enum MixedEnum {
+  Dog = "Dog",
+  Cat = "Cat",
+  Other = 1234,
+}
+
+const enum ConstEnum {
+  First = "first",
+  Second = "second",
+}
+
+enum ComputedEnum {
+  Gross = "Gross".length,
+  Foul = "Foul".length
+}
+
+// Single item enums, such as the below are actually supported as literal types because
+// the compiler simplifies them to the single literal type they can possibly be
+// enum SingleItemEnum {
+//   Single = "Single"
+//}
+
+enum ComputedSingleItemEnum {
+  Single = "Single".length
+}
+
+type StringLiteralEnum = "1st" | "2nd"
+
+type NumberLiteralEnum = 0 | 1 | 2
+
+type MixedLiteralEnum = true | false | 0 | 1 | "1st" | "2nd"
+
+const ConstObjEnumVal = {
+  Plant: "plant",
+  Animal: "animal"
+} as const;
+
+type ConstObjEnum = typeof ConstObjEnumVal[keyof typeof ConstObjEnumVal]
+
+/**
+ * @readonly
+ */
+export function enumTypes(
+  stringEnum: StringEnum,
+  numberEnum: NumberEnum,
+  mixedEnum: MixedEnum,
+  constEnum: ConstEnum,
+  computedEnum: ComputedEnum,
+  computedSingleItemEnum: ComputedSingleItemEnum,
+  stringLiteralEnum: StringLiteralEnum,
+  stringLiteralEnumMaybe: StringLiteralEnum | undefined,
+  inlineStringLiteralEnum: "1st" | "2nd",
+  inlineStringLiteralEnumMaybe: "1st" | "2nd" | null,
+  numberLiteralEnum: NumberLiteralEnum,
+  numberLiteralEnumMaybe: NumberLiteralEnum | null,
+  inlineNumberLiteralEnum: 0 | 1 | 2,
+  inlineNumberLiteralEnumMaybe: 0 | 1 | 2 | undefined,
+  mixedLiteralEnum: MixedLiteralEnum,
+  mixedLiteralEnumMaybe: MixedLiteralEnum | undefined | null,
+  inlineMixedLiteralEnum: true | 1 | "first",
+  inlineMixedLiteralEnumMaybe: true | 1 | "first" | undefined | null,
+  constObjEnum: ConstObjEnum,
+): string {
+  return ""
+}

--- a/ndc-lambda-sdk/test/inference/unsupported-types/unsupported-types.test.ts
+++ b/ndc-lambda-sdk/test/inference/unsupported-types/unsupported-types.test.ts
@@ -271,4 +271,42 @@ describe("unsupported types", function() {
       }
     })
   });
+
+  it("enum types", function() {
+    const schema = deriveSchema(require.resolve("./enum-types.ts"));
+
+    assert.deepStrictEqual(schema, {
+      compilerDiagnostics: [],
+      functionIssues: {
+        "enumTypes": [
+          "Enum types are not supported, but one was encountered in function 'enumTypes' parameter 'stringEnum' (type: StringEnum)",
+          "Enum types are not supported, but one was encountered in function 'enumTypes' parameter 'numberEnum' (type: NumberEnum)",
+          "Enum types are not supported, but one was encountered in function 'enumTypes' parameter 'mixedEnum' (type: MixedEnum)",
+          "Enum types are not supported, but one was encountered in function 'enumTypes' parameter 'constEnum' (type: ConstEnum)",
+          "Enum types are not supported, but one was encountered in function 'enumTypes' parameter 'computedEnum' (type: ComputedEnum)",
+          "Enum types are not supported, but one was encountered in function 'enumTypes' parameter 'computedSingleItemEnum' (type: ComputedSingleItemEnum)",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'stringLiteralEnum' (type: StringLiteralEnum)",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'stringLiteralEnumMaybe' (type: StringLiteralEnum)",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'inlineStringLiteralEnum' (type: \"1st\" | \"2nd\")",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'inlineStringLiteralEnumMaybe' (type: \"1st\" | \"2nd\")",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'numberLiteralEnum' (type: NumberLiteralEnum)",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'numberLiteralEnumMaybe' (type: NumberLiteralEnum)",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'inlineNumberLiteralEnum' (type: 0 | 1 | 2)",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'inlineNumberLiteralEnumMaybe' (type: 0 | 1 | 2)",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'mixedLiteralEnum' (type: MixedLiteralEnum)",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'mixedLiteralEnumMaybe' (type: MixedLiteralEnum)",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'inlineMixedLiteralEnum' (type: true | 1 | \"first\")",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'inlineMixedLiteralEnumMaybe' (type: true | 1 | \"first\")",
+          "Literal union types are not supported, but one was encountered in function 'enumTypes' parameter 'constObjEnum' (type: ConstObjEnum)",
+        ],
+      },
+      functionsSchema: {
+        scalarTypes: {
+          String: { type: "built-in" },
+        },
+        objectTypes: {},
+        functions: {}
+      }
+    })
+  });
 });


### PR DESCRIPTION
We've never supported enum types or unions of literals, but now we explicitly identify and block them with good error messages. Previously most instances of enums and unions of literals would have been blocked by other code (most enums have index signatures, and unions of literals are unions), but the error messages were unfriendly.

Now by explicitly identifying these kinds of types, we can display proper error messages mentioning enum types and also allow them under relaxed types. This fixes issues where unions of literals that previously would have _not_ been allowed under relaxed types now are allowed (for example, `"one" | "two" | undefined` was not allowed as a relaxed type).
This also lays the groundwork for properly supporting these types as enum types in the future.

The code around handling nullable types (`unwrapNullableType`) has also been refactored and improved to use `typeChecker.getNonNullableType`, which eliminates the manual handling of boolean unions.

We didn't actually have any explicit tests covering enum types, so a new `test/inference/unsupported-types/enum-types.ts` test scenario has been added to explicitly check that we've blocked different forms of enum types. `test/inference/relaxed-types/enum-types-[valid/invalid].ts` covers the behaviour when relaxed types are allowed.

The TS SDK version has also been updated to the latest version available. This will have no impact on the connector.

JIRA: [NLC-22](https://hasurahq.atlassian.net/browse/NLC-22)