### PR TITLE
Add Docker healthcheck and add node_modules to the .dockerignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes to be included in the next upcoming release
 
 - Improved error messages when unsupported enum types or unions of literal types are found, and allow these types to be used in relaxed types mode ([#17](https://github.com/hasura/ndc-nodejs-lambda/pull/17))
 - Improved naming of types that reside outside of the main `functions.ts` file. Type names will now only be prefixed with a disambiguator if there is a naming conflict detected (ie. where two different types use the same name). Anonymous types are now also named in a shorter way. ([#21](https://github.com/hasura/ndc-nodejs-lambda/pull/21))
+- Added a built-in Docker healthcheck, and ignored `node_modules` from the Docker build ([#22](https://github.com/hasura/ndc-nodejs-lambda/pull/22))
 
 ## [1.1.0] - 2024-02-26
 - Updated to [NDC TypeScript SDK v4.2.0](https://github.com/hasura/ndc-sdk-typescript/releases/tag/v4.2.0) to include OpenTelemetry improvements. Traced spans should now appear in the Hasura Console

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18-alpine
 
-RUN apk add jq
+RUN apk add jq curl
 
 COPY /docker /scripts
 
@@ -8,5 +8,7 @@ COPY /functions /functions
 RUN /scripts/package-restore.sh
 
 EXPOSE 8080
+
+HEALTHCHECK --interval=5s --timeout=10s --start-period=1s --retries=3 CMD [ "sh", "-c", "curl -f http://localhost:${HASURA_CONNECTOR_PORT:-8080}/health" ]
 
 CMD [ "sh", "/scripts/start.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN /scripts/package-restore.sh
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=5s --timeout=10s --start-period=1s --retries=3 CMD [ "sh", "-c", "curl -f http://localhost:${HASURA_CONNECTOR_PORT:-8080}/health" ]
+HEALTHCHECK --interval=5s --timeout=10s --start-period=1s --retries=3 CMD [ "sh", "-c", "exec curl -f http://localhost:${HASURA_CONNECTOR_PORT:-8080}/health" ]
 
 CMD [ "sh", "/scripts/start.sh" ]

--- a/connector-definition/.dockerignore
+++ b/connector-definition/.dockerignore
@@ -1,2 +1,3 @@
 .hasura-connector/
 *.hml
+node_modules/


### PR DESCRIPTION
The CLI will use the Docker healthcheck to make sure that the container is running before trying to refresh the schema (etc). 

Ignoring the `node_modules` folder also helps the CLI so that it doesn't include it when sending the build context to the build server; currently it tries to send it and fails because `node_modules` is too large.