### PR TITLE
Update NodeJS and TypeScript

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes to be included in the next upcoming release
 
 - Improved error messages when unsupported enum types or unions of literal types are found, and allow these types to be used in relaxed types mode ([#17](https://github.com/hasura/ndc-nodejs-lambda/pull/17))
 - Improved naming of types that reside outside of the main `functions.ts` file. Type names will now only be prefixed with a disambiguator if there is a naming conflict detected (ie. where two different types use the same name). Anonymous types are now also named in a shorter way. ([#21](https://github.com/hasura/ndc-nodejs-lambda/pull/21))
+- Updated NodeJS to v20 and TypeScript to v5.4.2 ([#23](https://github.com/hasura/ndc-nodejs-lambda/pull/23))
 
 ## [1.1.0] - 2024-02-26
 - Updated to [NDC TypeScript SDK v4.2.0](https://github.com/hasura/ndc-sdk-typescript/releases/tag/v4.2.0) to include OpenTelemetry improvements. Traced spans should now appear in the Hasura Console

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 RUN apk add jq
 

--- a/connector-definition/template/tsconfig.json
+++ b/connector-definition/template/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/@tsconfig/node18/tsconfig.json"
+  "extends": "./node_modules/@tsconfig/node20/tsconfig.json"
 }

--- a/ndc-lambda-sdk/bin/index.js
+++ b/ndc-lambda-sdk/bin/index.js
@@ -22,7 +22,7 @@ const tsConfigFileLocation =
     ? ts.findConfigFile(path.dirname(hostOpts.functions), ts.sys.fileExists)
     : undefined
   )
-  ?? require.resolve("@tsconfig/node18/tsconfig.json");
+  ?? require.resolve("@tsconfig/node20/tsconfig.json");
 const watchMode = hostOpts?.watch ?? false;
 
 const hostScriptPath = path.resolve(__dirname, "../dist/src/host.js")

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hasura/ndc-sdk-typescript": "^4.2.1",
-        "@tsconfig/node18": "^18.2.2",
+        "@tsconfig/node20": "^20.1.2",
         "commander": "^11.1.0",
         "cross-spawn": "^7.0.3",
         "p-limit": "^3.1.0",
@@ -932,10 +932,10 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
-      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw=="
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.2.tgz",
+      "integrity": "sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ=="
     },
     "node_modules/@types/chai": {
       "version": "4.3.11",

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -17,7 +17,7 @@
         "ts-api-utils": "^1.0.3",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^5.3.3"
+        "typescript": "^5.4.2"
       },
       "bin": {
         "ndc-lambda-sdk": "bin/index.js"
@@ -2963,9 +2963,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -38,7 +38,7 @@
     "ts-api-utils": "^1.0.3",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@hasura/ndc-sdk-typescript": "^4.2.1",
-    "@tsconfig/node18": "^18.2.2",
+    "@tsconfig/node20": "^20.1.2",
     "commander": "^11.1.0",
     "cross-spawn": "^7.0.3",
     "p-limit": "^3.1.0",

--- a/ndc-lambda-sdk/src/inference.ts
+++ b/ndc-lambda-sdk/src/inference.ts
@@ -67,7 +67,7 @@ function loadTsConfig(functionsFilePath: string): Result<ts.ParsedCommandLine, t
   const userTsConfig = ts.findConfigFile(functionsDir, ts.sys.fileExists);
   // If the user doesn't have a tsconfig, use this one as a fallback. The TypeScript defaults are bad
   // (eg. strict and strictNullChecks is off by default)
-  const fallbackTsConfig = path.resolve(require.resolve("@tsconfig/node18/tsconfig.json"));
+  const fallbackTsConfig = path.resolve(require.resolve("@tsconfig/node20/tsconfig.json"));
   const configPath = userTsConfig ?? fallbackTsConfig;
   const configFile = ts.readConfigFile(configPath, ts.sys.readFile)
   if (configFile.error) {

--- a/ndc-lambda-sdk/tsconfig.json
+++ b/ndc-lambda-sdk/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@tsconfig/node18/tsconfig.json",
+  "extends": "./node_modules/@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
     "resolveJsonModule": true,

--- a/yeoman-generator/package-lock.json
+++ b/yeoman-generator/package-lock.json
@@ -20,7 +20,7 @@
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^11.0.0",
         "ts-loader": "^9.5.1",
-        "typescript": "^5.3.3",
+        "typescript": "^5.4.2",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4"
       }
@@ -4747,9 +4747,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/yeoman-generator/package-lock.json
+++ b/yeoman-generator/package-lock.json
@@ -13,7 +13,7 @@
         "yeoman-generator": "^5.10.0"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.2",
+        "@tsconfig/node20": "^20.1.2",
         "@types/pacote": "^11.1.8",
         "@types/semver": "^7.5.6",
         "@types/yeoman-generator": "^5.2.14",
@@ -673,10 +673,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
-      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.2.tgz",
+      "integrity": "sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==",
       "dev": true
     },
     "node_modules/@tufjs/canonical-json": {

--- a/yeoman-generator/package.json
+++ b/yeoman-generator/package.json
@@ -24,7 +24,7 @@
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",
     "ts-loader": "^9.5.1",
-    "typescript": "^5.3.3",
+    "typescript": "^5.4.2",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4"
   }

--- a/yeoman-generator/package.json
+++ b/yeoman-generator/package.json
@@ -17,7 +17,7 @@
     "yeoman-generator": "^5.10.0"
   },
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.2",
+    "@tsconfig/node20": "^20.1.2",
     "@types/pacote": "^11.1.8",
     "@types/semver": "^7.5.6",
     "@types/yeoman-generator": "^5.2.14",

--- a/yeoman-generator/src/app/templates/tsconfig.json
+++ b/yeoman-generator/src/app/templates/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/@tsconfig/node18/tsconfig.json"
+  "extends": "./node_modules/@tsconfig/node20/tsconfig.json"
 }

--- a/yeoman-generator/tsconfig.json
+++ b/yeoman-generator/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@tsconfig/node18/tsconfig.json",
+  "extends": "./node_modules/@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
     "resolveJsonModule": true,


### PR DESCRIPTION
This PR updates NodeJS from v18 to v20 (the latest production-supported version), and TypeScript from 5.3 to 5.4.