### PR TITLE
Fix watch mode not reloading after files with compiler errors are fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+- Fixed watch mode not reloading after files with compiler errors are changed [#27](https://github.com/hasura/ndc-nodejs-lambda/pull/27)
+
 ## [1.2.0] - 2024-03-18
 - Improved error messages when unsupported enum types or unions of literal types are found, and allow these types to be used in relaxed types mode ([#17](https://github.com/hasura/ndc-nodejs-lambda/pull/17))
 - Improved naming of types that reside outside of the main `functions.ts` file. Type names will now only be prefixed with a disambiguator if there is a naming conflict detected (ie. where two different types use the same name). Anonymous types are now also named in a shorter way. ([#21](https://github.com/hasura/ndc-nodejs-lambda/pull/21))

--- a/ndc-lambda-sdk/bin/index.js
+++ b/ndc-lambda-sdk/bin/index.js
@@ -27,7 +27,7 @@ const watchMode = hostOpts?.watch ?? false;
 
 const hostScriptPath = path.resolve(__dirname, "../dist/src/host.js")
 const projectArgs = tsConfigFileLocation ? ["--project", tsConfigFileLocation] : []
-const tsNodeArgs = [...projectArgs, "--transpile-only", hostScriptPath, ...process.argv.slice(2)];
+const tsNodeArgs = [...projectArgs, "--pretty", hostScriptPath, ...process.argv.slice(2)];
 
 const [command, args] =
   watchMode


### PR DESCRIPTION
This PR fixes a bug in watch mode, where, if you had compile errors in your functions TypeScript code, after fixing the compile errors, the connector would not be restarted to reload your changes. Now, when you change your (broken) files, the connector will reload and retry to compile your code.

This was caused by an optimisation where we performed schema inference and if we got TS compiler errors, we skipped `require`-ing the function code into the app. We did this because we wanted to avoid compiling the code twice, and also because the compilation via `require` would produce extra error output in the terminal. Unfortunately, because we skipped `require`, we skipped the registration of the function code into the hot-reloading watching system provided by `ts-node-dev`.

To fix this, I've removed this optimisation. We now always `require` the functions code, and we let `ts-node` do a full type-checked compile (not just a transpile), so if it fails, we get the full compiler errors and output those to the terminal and then skip schema inference. If there are no compiler errors and the code successfully imports via `require`, we then do schema inference.