### PR TITLE
Fixed functions that are imported then re-exported causing a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+- Fixed functions that are imported then re-exported causing a crash [#28](https://github.com/hasura/ndc-nodejs-lambda/pull/28)
+
 ## [1.2.0] - 2024-03-18
 - Improved error messages when unsupported enum types or unions of literal types are found, and allow these types to be used in relaxed types mode ([#17](https://github.com/hasura/ndc-nodejs-lambda/pull/17))
 - Improved naming of types that reside outside of the main `functions.ts` file. Type names will now only be prefixed with a disambiguator if there is a naming conflict detected (ie. where two different types use the same name). Anonymous types are now also named in a shorter way. ([#21](https://github.com/hasura/ndc-nodejs-lambda/pull/21))

--- a/ndc-lambda-sdk/test/inference/re-exported-functions/functions-import-then-export.ts
+++ b/ndc-lambda-sdk/test/inference/re-exported-functions/functions-import-then-export.ts
@@ -1,0 +1,8 @@
+import { fileAChildFunction as renamedFileAChildFunction } from "./file-a"
+import { fileBChildFunction1, fileBChildFunction2 } from "./file-b"
+
+export {
+  renamedFileAChildFunction,
+  fileBChildFunction1,
+  fileBChildFunction2 as renamedFileBChildFunction2
+};

--- a/ndc-lambda-sdk/test/inference/re-exported-functions/re-exported-functions.test.ts
+++ b/ndc-lambda-sdk/test/inference/re-exported-functions/re-exported-functions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "mocha";
 import { assert } from "chai";
 import { deriveSchema } from "../../../src/inference";
-import { BuiltInScalarTypeName, FunctionNdcKind, NullOrUndefinability } from "../../../src/schema";
+import { FunctionNdcKind } from "../../../src/schema";
 
 describe("re-exported functions", function() {
   it("supports functions re-exported from other files", function() {
@@ -200,6 +200,67 @@ describe("re-exported functions", function() {
           },
         },
         scalarTypes: {
+          String: { type: "built-in" },
+        },
+        objectTypes: {},
+      }
+    })
+  });
+
+  it("supports re-exports of functions from other files that are first imported then exported", function() {
+    const schema = deriveSchema(require.resolve("./functions-import-then-export.ts"));
+
+    assert.deepStrictEqual(schema, {
+      compilerDiagnostics: [],
+      functionIssues: {},
+      functionsSchema: {
+        functions: {
+          "renamedFileAChildFunction": {
+            ndcKind: FunctionNdcKind.Procedure,
+            description: null,
+            parallelDegree: null,
+            arguments: [],
+            resultType: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            }
+          },
+          "fileBChildFunction1": {
+            ndcKind: FunctionNdcKind.Procedure,
+            description: null,
+            parallelDegree: null,
+            arguments: [],
+            resultType: {
+              name: "Boolean",
+              kind: "scalar",
+              type: "named",
+            }
+          },
+          "renamedFileBChildFunction2": {
+            ndcKind: FunctionNdcKind.Function,
+            description: null,
+            parallelDegree: null,
+            arguments: [
+              {
+                argumentName: "input",
+                description: null,
+                type: {
+                  name: "String",
+                  kind: "scalar",
+                  type: "named",
+                }
+              }
+            ],
+            resultType: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            }
+          },
+        },
+        scalarTypes: {
+          Boolean: { type: "built-in" },
           String: { type: "built-in" },
         },
         objectTypes: {},


### PR DESCRIPTION
This PR fixes a bug where if one was to re-export functions from another file like so:

```typescript
import { fileBChildFunction1 } from "./file-b";

export { fileBChildFunction1 };
```

you would cause the type inference to crash. This PR fixes the type inference so it correctly handles this corner case by following the import symbol's alias to its source then getting its declaration.