### PR TITLE
Update to TS SDK v4.4.0 (NDC Spec v0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changes to be included in the next upcoming release
 
 - Fixed watch mode not reloading after files with compiler errors are changed [#27](https://github.com/hasura/ndc-nodejs-lambda/pull/27)
 - Fixed functions that are imported then re-exported causing a crash [#28](https://github.com/hasura/ndc-nodejs-lambda/pull/28)
+- Support for NDC Spec v0.1.2 via the NDC TypeScript SDK v4.4.0 ([#29](https://github.com/hasura/ndc-nodejs-lambda/pull/29)).
+  - Built-in scalar types that support equality now define it in the NDC schema.
+  - Built-in scalar types now have an explicit type representation defined in the NDC schema.
 
 ## [1.2.0] - 2024-03-18
 - Improved error messages when unsupported enum types or unions of literal types are found, and allow these types to be used in relaxed types mode ([#17](https://github.com/hasura/ndc-nodejs-lambda/pull/17))

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Node.js Lambda connector allows you to expose TypeScript functions as NDC fu
 > Hasura DDN Alpha users should use 0.x versions of the `ndc-lambda-sdk`. v1.x versions of the `ndc-lambda-sdk` support the forthcoming Hasura DDN Beta.
 
 ## How to Use
-First, ensure you have Node.js v18+ installed. Then, create a directory into which you will create your functions using the `hasura-ndc-nodejs-lambda` Yeoman template.
+First, ensure you have Node.js v20+ installed. Then, create a directory into which you will create your functions using the `hasura-ndc-nodejs-lambda` Yeoman template.
 
 ```bash
 mkdir my-functions

--- a/connector-definition/template/package.json
+++ b/connector-definition/template/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "start": "ndc-lambda-sdk host -f functions.ts serve --configuration ./",

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -10,14 +10,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hasura/ndc-sdk-typescript": "^4.2.1",
-        "@tsconfig/node20": "^20.1.2",
+        "@tsconfig/node20": "^20.1.3",
         "commander": "^11.1.0",
         "cross-spawn": "^7.0.3",
         "p-limit": "^3.1.0",
-        "ts-api-utils": "^1.0.3",
+        "ts-api-utils": "^1.3.0",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^5.4.2"
+        "typescript": "^5.4.3"
       },
       "bin": {
         "ndc-lambda-sdk": "bin/index.js"
@@ -933,9 +933,9 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@tsconfig/node20": {
-      "version": "20.1.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.2.tgz",
-      "integrity": "sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ=="
+      "version": "20.1.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.3.tgz",
+      "integrity": "sha512-XeWn6Gms5MaQWdj+C4fuxuo/Icy8ckh+BwAIijhX2LKRHHt1OuctLLLlB0F4EPi55m2IUJNTnv8FH9kSBI7Ogw=="
     },
     "node_modules/@types/chai": {
       "version": "4.3.11",
@@ -2857,11 +2857,11 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
-      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
       "engines": {
-        "node": ">=16.13.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
@@ -2963,9 +2963,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hasura/ndc-sdk-typescript": "^4.2.1",
+        "@hasura/ndc-sdk-typescript": "^4.4.0",
         "@tsconfig/node20": "^20.1.3",
         "commander": "^11.1.0",
         "cross-spawn": "^7.0.3",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@hasura/ndc-sdk-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-4.2.1.tgz",
-      "integrity": "sha512-NbrbHTcCZsgG8EfVxfHsdwDCc6i+SJ40HqiOJau9p/RhDtif2HH7zoAa+9V2Bnyn2rPPYOFdZM46iHagOCei6Q==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-4.4.0.tgz",
+      "integrity": "sha512-tz4GPO+HmcXm4TvWjqjXjTGv0vTJWqcoydtDA1aiDEqUsUqx/nukfdwtaQM7CQa/Knv8Ov7FqMAMs7IEFQiAWw==",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@opentelemetry/api": "^1.7.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -30,7 +30,7 @@
     "url": "git+https://github.com/hasura/ndc-nodejs-lambda.git"
   },
   "dependencies": {
-    "@hasura/ndc-sdk-typescript": "^4.2.1",
+    "@hasura/ndc-sdk-typescript": "^4.4.0",
     "@tsconfig/node20": "^20.1.3",
     "commander": "^11.1.0",
     "cross-spawn": "^7.0.3",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -31,14 +31,14 @@
   },
   "dependencies": {
     "@hasura/ndc-sdk-typescript": "^4.2.1",
-    "@tsconfig/node20": "^20.1.2",
+    "@tsconfig/node20": "^20.1.3",
     "commander": "^11.1.0",
     "cross-spawn": "^7.0.3",
     "p-limit": "^3.1.0",
-    "ts-api-utils": "^1.0.3",
+    "ts-api-utils": "^1.3.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",

--- a/ndc-lambda-sdk/src/connector.ts
+++ b/ndc-lambda-sdk/src/connector.ts
@@ -67,7 +67,7 @@ export function createConnector(options: ConnectorOptions): sdk.Connector<Config
 
     getCapabilities: function (configuration: Configuration): sdk.CapabilitiesResponse {
       return {
-        version: "0.1.1",
+        version: "0.1.2",
         capabilities: {
           query: {
             variables: {}

--- a/ndc-lambda-sdk/src/connector.ts
+++ b/ndc-lambda-sdk/src/connector.ts
@@ -67,7 +67,7 @@ export function createConnector(options: ConnectorOptions): sdk.Connector<Config
 
     getCapabilities: function (configuration: Configuration): sdk.CapabilitiesResponse {
       return {
-        version: "0.1.0",
+        version: "0.1.1",
         capabilities: {
           query: {
             variables: {}

--- a/ndc-lambda-sdk/src/schema.ts
+++ b/ndc-lambda-sdk/src/schema.ts
@@ -298,7 +298,7 @@ function convertBuiltInScalarTypeIntoSdkSchemaType(typeName: BuiltInScalarTypeNa
       comparison_operators: { "_eq": { type: "equal" } },
     };
     case BuiltInScalarTypeName.BigInt: return {
-      representation: { type: "string" }, // NDC doesn't have a good representation for this type as at v0.1.2, so this is the best representation in the meantime
+      representation: { type: "int64" }, // NDC doesn't have a good representation for this type as at v0.1.2, so this is the best representation in the meantime
       aggregate_functions: {},
       comparison_operators: { "_eq": { type: "equal" } },
     };

--- a/ndc-lambda-sdk/src/schema.ts
+++ b/ndc-lambda-sdk/src/schema.ts
@@ -1,5 +1,5 @@
 import * as sdk from "@hasura/ndc-sdk-typescript";
-import { mapObjectValues, unreachable } from "./util";
+import { mapObjectValues, throwError, unreachable } from "./util";
 
 export type FunctionsSchema = {
   functions: FunctionDefinitions
@@ -243,11 +243,18 @@ export function getNdcSchema(functionsSchema: FunctionsSchema): sdk.SchemaRespon
   });
 
   const scalarTypes: Record<string, sdk.ScalarType> = mapObjectValues(functionsSchema.scalarTypes, (scalarDef, scalarTypeName) => {
-    return {
-      aggregate_functions: {},
-      comparison_operators: scalarDef.type === "built-in" && isTypeNameBuiltInScalar(scalarTypeName) && builtInScalarSupportsEquality(scalarTypeName)
-      ? <Record<string, sdk.ComparisonOperatorDefinition>>{ "_eq": { type: "equal" } }
-      : {},
+    switch (scalarDef.type) {
+      case "built-in":
+        return isTypeNameBuiltInScalar(scalarTypeName)
+          ? convertBuiltInScalarTypeIntoSdkSchemaType(scalarTypeName)
+          : throwError(`built-in scalar type with unexpected name: ${scalarTypeName}`);
+      case "relaxed-type":
+        return {
+          aggregate_functions: {},
+          comparison_operators: {},
+        };
+      default:
+        return unreachable(scalarDef["type"]);
     }
   })
 
@@ -270,6 +277,42 @@ function convertTypeReferenceToSdkType(typeRef: TypeReference): sdk.Type {
     case "nullable": return { type: "nullable", underlying_type: convertTypeReferenceToSdkType(typeRef.underlyingType) }
     case "named": return { type: "named", name: typeRef.name }
     default: return unreachable(typeRef["type"])
+  }
+}
+
+function convertBuiltInScalarTypeIntoSdkSchemaType(typeName: BuiltInScalarTypeName): sdk.ScalarType {
+  switch (typeName) {
+    case BuiltInScalarTypeName.String: return {
+      representation: { type: "string" },
+      aggregate_functions: {},
+      comparison_operators: { "_eq": { type: "equal" } },
+    };
+    case BuiltInScalarTypeName.Float: return {
+      representation: { type: "float64" },
+      aggregate_functions: {},
+      comparison_operators: { "_eq": { type: "equal" } },
+    };
+    case BuiltInScalarTypeName.Boolean: return {
+      representation: { type: "boolean" },
+      aggregate_functions: {},
+      comparison_operators: { "_eq": { type: "equal" } },
+    };
+    case BuiltInScalarTypeName.BigInt: return {
+      representation: { type: "string" }, // NDC doesn't have a good representation for this type as at v0.1.2, so this is the best representation in the meantime
+      aggregate_functions: {},
+      comparison_operators: { "_eq": { type: "equal" } },
+    };
+    case BuiltInScalarTypeName.DateTime: return {
+      representation: { type: "timestamp" },
+      aggregate_functions: {},
+      comparison_operators: { "_eq": { type: "equal" } },
+    };
+    case BuiltInScalarTypeName.JSON: return {
+      representation: { type: "json" },
+      aggregate_functions: {},
+      comparison_operators: {},
+    };
+    default: return unreachable(typeName);
   }
 }
 
@@ -331,16 +374,4 @@ export function isTypeNameBuiltInScalar(typeName: string): typeName is BuiltInSc
 
 export function isBuiltInScalarTypeReference(typeReference: NamedScalarTypeReference): typeReference is BuiltInScalarTypeReference {
   return isTypeNameBuiltInScalar(typeReference.name);
-}
-
-function builtInScalarSupportsEquality(typeName: BuiltInScalarTypeName) {
-  switch (typeName) {
-    case BuiltInScalarTypeName.String: return true;
-    case BuiltInScalarTypeName.Float: return true;
-    case BuiltInScalarTypeName.Boolean: return true;
-    case BuiltInScalarTypeName.BigInt: return true;
-    case BuiltInScalarTypeName.DateTime: return true;
-    case BuiltInScalarTypeName.JSON: return false;
-    default: return unreachable(typeName);
-  }
 }

--- a/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
+++ b/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
@@ -233,7 +233,7 @@ describe("ndc schema", function() {
           }
         },
         "BigInt": {
-          representation: { type: "string" },
+          representation: { type: "int64" },
           aggregate_functions: {},
           comparison_operators: {
             "_eq": { type: "equal" }

--- a/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
+++ b/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
@@ -19,7 +19,7 @@ describe("ndc schema", function() {
                 nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
                 underlyingType: {
                   kind: "scalar",
-                  name: "String",
+                  name: "Float",
                   type: "named",
                 },
               },
@@ -30,7 +30,7 @@ describe("ndc schema", function() {
             nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
             underlyingType: {
               kind: "scalar",
-              name: "String",
+              name: "BigInt",
               type: "named",
             }
           },
@@ -46,6 +46,15 @@ describe("ndc schema", function() {
               type: {
                 kind: "object",
                 name: "MyObject",
+                type: "named",
+              },
+            },
+            {
+              argumentName: "myRelaxedType",
+              description: "My relaxed type param",
+              type: {
+                kind: "scalar",
+                name: "MyRelaxedType",
                 type: "named",
               },
             },
@@ -65,23 +74,23 @@ describe("ndc schema", function() {
           description: "My Object Type",
           properties: [
             {
-              propertyName: "string",
-              description: "A string",
+              propertyName: "boolean",
+              description: "A boolean",
               type: {
                 kind: "scalar",
-                name: "String",
+                name: "Boolean",
                 type: "named",
               },
             },
             {
-              propertyName: "nullableString",
-              description: "A nullable string",
+              propertyName: "nullableDateTime",
+              description: "A nullable date time",
               type: {
                 type: "nullable",
                 nullOrUndefinability: NullOrUndefinability.AcceptsNullOnly,
                 underlyingType: {
                   kind: "scalar",
-                  name: "String",
+                  name: "DateTime",
                   type: "named",
                 },
               },
@@ -91,8 +100,24 @@ describe("ndc schema", function() {
         },
       },
       scalarTypes: {
-        String: { type: "built-in" },
-        test_arguments_unionWithNull: { type: "built-in" },
+        "String": { type: "built-in" },
+        "Boolean": { type: "built-in" },
+        "Float": { type: "built-in" },
+        "DateTime": { type: "built-in" },
+        "BigInt": { type: "built-in" },
+        "JSON": { type: "built-in" },
+        "MyRelaxedType": {
+          type: "relaxed-type",
+          usedIn: [
+            [
+              {
+                segmentType: "FunctionParameter",
+                functionName: "test_func",
+                parameterName: "myRelaxedType"
+              }
+            ]
+          ]
+        },
       },
     };
 
@@ -109,6 +134,13 @@ describe("ndc schema", function() {
               description: "My object param",
               type: {
                 name: "MyObject",
+                type: "named",
+              },
+            },
+            "myRelaxedType": {
+              description: "My relaxed type param",
+              type: {
+                name: "MyRelaxedType",
                 type: "named",
               },
             },
@@ -132,7 +164,7 @@ describe("ndc schema", function() {
               type: {
                 type: "nullable",
                 underlying_type: {
-                  name: "String",
+                  name: "Float",
                   type: "named",
                 },
               },
@@ -141,7 +173,7 @@ describe("ndc schema", function() {
           result_type: {
             type: "nullable",
             underlying_type: {
-              name: "String",
+              name: "BigInt",
               type: "named",
             }
           },
@@ -151,19 +183,19 @@ describe("ndc schema", function() {
         "MyObject": {
           description: "My Object Type",
           fields: {
-            "string": {
-              description: "A string",
+            "boolean": {
+              description: "A boolean",
               type: {
-                name: "String",
+                name: "Boolean",
                 type: "named",
               },
             },
-            "nullableString": {
-              description: "A nullable string",
+            "nullableDateTime": {
+              description: "A nullable date time",
               type: {
                 type: "nullable",
                 underlying_type: {
-                  name: "String",
+                  name: "DateTime",
                   type: "named",
                 },
               },
@@ -172,11 +204,41 @@ describe("ndc schema", function() {
         },
       },
       scalar_types: {
-        String: {
+        "String": {
+          aggregate_functions: {},
+          comparison_operators: {
+            "_eq": { type: "equal" }
+          }
+        },
+        "Boolean": {
+          aggregate_functions: {},
+          comparison_operators: {
+            "_eq": { type: "equal" }
+          }
+        },
+        "Float": {
+          aggregate_functions: {},
+          comparison_operators: {
+            "_eq": { type: "equal" }
+          }
+        },
+        "DateTime": {
+          aggregate_functions: {},
+          comparison_operators: {
+            "_eq": { type: "equal" }
+          }
+        },
+        "BigInt": {
+          aggregate_functions: {},
+          comparison_operators: {
+            "_eq": { type: "equal" }
+          }
+        },
+        "JSON": {
           aggregate_functions: {},
           comparison_operators: {}
         },
-        test_arguments_unionWithNull: {
+        "MyRelaxedType": {
           aggregate_functions: {},
           comparison_operators: {}
         },

--- a/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
+++ b/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
@@ -205,36 +205,42 @@ describe("ndc schema", function() {
       },
       scalar_types: {
         "String": {
+          representation: { type: "string" },
           aggregate_functions: {},
           comparison_operators: {
             "_eq": { type: "equal" }
           }
         },
         "Boolean": {
+          representation: { type: "boolean" },
           aggregate_functions: {},
           comparison_operators: {
             "_eq": { type: "equal" }
           }
         },
         "Float": {
+          representation: { type: "float64" },
           aggregate_functions: {},
           comparison_operators: {
             "_eq": { type: "equal" }
           }
         },
         "DateTime": {
+          representation: { type: "timestamp" },
           aggregate_functions: {},
           comparison_operators: {
             "_eq": { type: "equal" }
           }
         },
         "BigInt": {
+          representation: { type: "string" },
           aggregate_functions: {},
           comparison_operators: {
             "_eq": { type: "equal" }
           }
         },
         "JSON": {
+          representation: { type: "json" },
           aggregate_functions: {},
           comparison_operators: {}
         },

--- a/yeoman-generator/package-lock.json
+++ b/yeoman-generator/package-lock.json
@@ -13,14 +13,14 @@
         "yeoman-generator": "^5.10.0"
       },
       "devDependencies": {
-        "@tsconfig/node20": "^20.1.2",
+        "@tsconfig/node20": "^20.1.3",
         "@types/pacote": "^11.1.8",
         "@types/semver": "^7.5.6",
         "@types/yeoman-generator": "^5.2.14",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^11.0.0",
         "ts-loader": "^9.5.1",
-        "typescript": "^5.4.2",
+        "typescript": "^5.4.3",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4"
       }
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@tsconfig/node20": {
-      "version": "20.1.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.2.tgz",
-      "integrity": "sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==",
+      "version": "20.1.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.3.tgz",
+      "integrity": "sha512-XeWn6Gms5MaQWdj+C4fuxuo/Icy8ckh+BwAIijhX2LKRHHt1OuctLLLlB0F4EPi55m2IUJNTnv8FH9kSBI7Ogw==",
       "dev": true
     },
     "node_modules/@tufjs/canonical-json": {
@@ -4747,9 +4747,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/yeoman-generator/package.json
+++ b/yeoman-generator/package.json
@@ -17,14 +17,14 @@
     "yeoman-generator": "^5.10.0"
   },
   "devDependencies": {
-    "@tsconfig/node20": "^20.1.2",
+    "@tsconfig/node20": "^20.1.3",
     "@types/pacote": "^11.1.8",
     "@types/semver": "^7.5.6",
     "@types/yeoman-generator": "^5.2.14",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",
     "ts-loader": "^9.5.1",
-    "typescript": "^5.4.2",
+    "typescript": "^5.4.3",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4"
   }

--- a/yeoman-generator/src/app/index.ts
+++ b/yeoman-generator/src/app/index.ts
@@ -83,7 +83,7 @@ export default class extends Generator {
     this.packageJson.merge({
       "private": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "scripts": {
         "start": `ndc-lambda-sdk host -f functions.ts serve --configuration ${configuration}`,


### PR DESCRIPTION
This PR updates the NDC TypeScript SDK used to v4.4.0, which brings support for NDC Spec v0.1.2.

Built-in scalar types now specify a [type representation](https://hasura.github.io/ndc-spec/specification/schema/scalar-types.html#type-representations) and if the type supports equality, that operator is defined.

Also: a few references to Node v18 have been updated to v20, since we now run on v20. These were missed when we bumped the version in #23.