### PR TITLE
Add support for native connector packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes to be included in the next upcoming release
   - Built-in scalar types that support equality now define it in the NDC schema.
   - Built-in scalar types now have an explicit type representation defined in the NDC schema.
 - Fixed functions that return null causing crashes ([#31](https://github.com/hasura/ndc-nodejs-lambda/pull/31))
+- Added support for native connector packaging ([#30](https://github.com/hasura/ndc-nodejs-lambda/pull/30))
 
 ## [1.2.0] - 2024-03-18
 - Improved error messages when unsupported enum types or unions of literal types are found, and allow these types to be used in relaxed types mode ([#17](https://github.com/hasura/ndc-nodejs-lambda/pull/17))

--- a/connector-definition/Makefile
+++ b/connector-definition/Makefile
@@ -10,7 +10,6 @@ build: dist/connector-definition.tgz
 .PHONY: clean
 clean:
 	rm -rf dist
-	rm -f connector-definition.tgz
 
 dist dist/.hasura-connector:
 	mkdir dist
@@ -32,6 +31,12 @@ dist_template_files := $(patsubst template/%,dist/%,$(template_files))
 $(dist_template_files): $(template_files)
 	cp -f $(template_files) dist/
 
+script_files := $(wildcard scripts/*)
+dist_script_files := $(patsubst scripts/%,dist/.hasura-connector/%,$(script_files))
+
+$(dist_script_files): $(script_files)
+	cp -f $(script_files) dist/.hasura-connector/
+
 dist/package.json: template/package.json $(RELEASE_VERSION_DEP)
 	cp -f template/package.json dist/
 	jq '.dependencies["@hasura/ndc-lambda-sdk"] = "$(RELEASE_VERSION)"' dist/package.json > dist/package.json.tmp
@@ -41,5 +46,5 @@ dist/package-lock.json: dist/package.json
 	cd dist && npm install
 	rm -rf dist/node_modules
 
-dist/connector-definition.tgz: dist/.hasura-connector/connector-metadata.yaml dist/.hasura-connector/Dockerfile dist/.hasura-connector/.dockerignore $(dist_template_files) dist/package-lock.json
+dist/connector-definition.tgz: dist/.hasura-connector/connector-metadata.yaml dist/.hasura-connector/Dockerfile dist/.hasura-connector/.dockerignore $(dist_template_files) dist/package-lock.json $(dist_script_files)
 	shopt -s dotglob && cd dist && tar -czvf connector-definition.tgz *

--- a/connector-definition/connector-metadata.yaml
+++ b/connector-definition/connector-metadata.yaml
@@ -1,5 +1,15 @@
 packagingDefinition:
   type: ManagedDockerBuild
+nativeToolchainDefinition:
+  commands:
+    start:
+      type: ShellScript
+      bash: ./start.sh
+      powershell: ./start.ps1
+    watch:
+      type: ShellScript
+      bash: ./watch.sh
+      powershell: ./watch.ps1
 supportedEnvironmentVariables: []
 commands: {}
 dockerComposeWatch:

--- a/connector-definition/scripts/check-reqs.ps1
+++ b/connector-definition/scripts/check-reqs.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = "Stop"
+
+$minimumNodeVersion = 20
+
+if (-not (Get-Command "node" -ErrorAction SilentlyContinue)) {
+  Write-Host "node could not be found. Please install NodeJS v$minimumNodeVersion+."
+  exit 1
+}
+
+$nodeVersion = & node --version
+if ($nodeVersion -match "^v(\d+)\.") {
+  $majorVersion = $Matches[1]
+  if ($majorVersion -lt $minimumNodeVersion) {
+    Write-Host "Detected Node.js version $nodeVersion on the PATH. The minimum required version is v$minimumNodeVersion."
+    exit 1
+  }
+}
+
+Set-Location $env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
+
+if ((Test-Path "./node_modules") -eq $false) {
+  Write-Host "node_modules not found, please ensure you have run 'npm install'."
+  exit 1
+}

--- a/connector-definition/scripts/check-reqs.ps1
+++ b/connector-definition/scripts/check-reqs.ps1
@@ -16,9 +16,12 @@ if ($nodeVersion -match "^v(\d+)\.") {
   }
 }
 
-Set-Location $env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
-
-if ((Test-Path "./node_modules") -eq $false) {
-  Write-Host "node_modules not found, please ensure you have run 'npm install'."
-  exit 1
+Push-Location $env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
+try {
+  if ((Test-Path "./node_modules") -eq $false) {
+    Write-Host "node_modules not found, please ensure you have run 'npm install'."
+    exit 1
+  }
+} finally {
+  Pop-Location
 }

--- a/connector-definition/scripts/check-reqs.sh
+++ b/connector-definition/scripts/check-reqs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+minimum_node_version="20"
+
+if ! command -v node &> /dev/null
+then
+  echo "node could not be found on the PATH. Please install Node.js v$minimum_node_version+."
+  exit 1
+fi
+
+node_version=$(node --version)
+if [[ "$node_version" =~ ^v([[:digit:]]+)\. ]]; then
+  major_version="${BASH_REMATCH[1]}"
+  if [[ $major_version -lt $minimum_node_version ]]; then
+    echo "Detected Node.js version $node_version on the PATH. The minimum required version is v$minimum_node_version."
+    exit 1
+  fi
+else
+  echo "no match"
+fi
+
+cd $HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
+
+if [ ! -d "node_modules" ]
+then
+  echo "node_modules directory not found, please ensure you have run 'npm install'."
+  exit 1
+fi

--- a/connector-definition/scripts/read-package-script.js
+++ b/connector-definition/scripts/read-package-script.js
@@ -1,0 +1,29 @@
+// This script reads from the package.json file in the current working directory
+// and prints out the text in the "scripts.<name>" entry. This is used to bypass
+// npm, which does not handle signals correctly, and execute the command directly
+
+const fs = require("node:fs");
+const process = require("node:process");
+const path = require("node:path");
+
+const cwd = process.cwd();
+const packageJsonPath = path.join(cwd, "./package.json");
+
+if (process.argv.length < 3) {
+  console.error("Error: Pass the name of script command you want to read as the first command line arg.");
+  console.error("Usage: node read-package-script.js <name>");
+  process.exit(1);
+}
+const desiredScript = process.argv[2];
+
+try {
+  const packageJsonText = fs.readFileSync(packageJsonPath);
+  const packageJson = JSON.parse(packageJsonText);
+  const script = packageJson.scripts[desiredScript];
+  if (script === undefined) {
+    console.error(`Error: script ${desiredScript} not found in ${packageJsonPath}`)
+  }
+  console.log(script);
+} catch (e) {
+  console.error(`Error reading ${packageJsonPath}: ${e}`);
+}

--- a/connector-definition/scripts/start.ps1
+++ b/connector-definition/scripts/start.ps1
@@ -1,6 +1,17 @@
 $ErrorActionPreference = "Stop"
 
+$scriptDir = Get-Location
+
 & ./check-reqs.ps1
 
-Set-Location $env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
-& npm run start
+Push-Location $env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
+try {
+  $startScript = & node "$PSScriptRoot\read-package-script.js" "start"
+  if ($LASTEXITCODE -ne 0) {
+    exit 1
+  }
+  $env:PATH = "$($env:PATH);$($env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH)\node_modules\.bin"
+  Invoke-Expression "& $startScript"
+} finally {
+  Pop-Location
+}

--- a/connector-definition/scripts/start.ps1
+++ b/connector-definition/scripts/start.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+
+& ./check-reqs.ps1
+
+Set-Location $env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
+& npm run start

--- a/connector-definition/scripts/start.sh
+++ b/connector-definition/scripts/start.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+script_dir=$(pwd)
+
 ./check-reqs.sh
 
 cd $HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
-npm run start
+start_script=$(node "$script_dir/read-package-script.js" "start")
+PATH="$PATH:$(pwd)/node_modules/.bin" exec $start_script

--- a/connector-definition/scripts/start.sh
+++ b/connector-definition/scripts/start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+./check-reqs.sh
+
+cd $HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
+npm run start

--- a/connector-definition/scripts/watch.ps1
+++ b/connector-definition/scripts/watch.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+
+& ./check-reqs.ps1
+
+Set-Location $env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
+& npm run watch

--- a/connector-definition/scripts/watch.ps1
+++ b/connector-definition/scripts/watch.ps1
@@ -1,6 +1,17 @@
 $ErrorActionPreference = "Stop"
 
+$scriptDir = Get-Location
+
 & ./check-reqs.ps1
 
-Set-Location $env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
-& npm run watch
+Push-Location $env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
+try {
+  $watchScript = & node "$PSScriptRoot\read-package-script.js" "watch"
+  if ($LASTEXITCODE -ne 0) {
+    exit 1
+  }
+  $env:PATH = "$($env:PATH);$($env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH)\node_modules\.bin"
+  Invoke-Expression "& $watchScript"
+} finally {
+  Pop-Location
+}

--- a/connector-definition/scripts/watch.sh
+++ b/connector-definition/scripts/watch.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+script_dir=$(pwd)
+
 ./check-reqs.sh
 
 cd $HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
-npm run watch
+watch_script=$(node "$script_dir/read-package-script.js" "watch")
+PATH="$PATH:$(pwd)/node_modules/.bin" exec $watch_script

--- a/connector-definition/scripts/watch.sh
+++ b/connector-definition/scripts/watch.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+./check-reqs.sh
+
+cd $HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
+npm run watch


### PR DESCRIPTION
This PR adds support for [Native Connector Packaging](https://github.com/hasura/ndc-hub/blob/main/rfcs/0004-native-packaging.md), allowing `ddn` to run the connector using NodeJS installed on the end-user's machine, rather than running it in a docker container.

There are three scripts created, in both bash and PowerShell:
- `check-reqs`: This checks the user's local environment to ensure nodejs is installed, ensure they have the correct version installed, and a smoke test of `node_modules` to make sure they've initialized their project correctly with `npm install` (standard Node project practice)
- `start`: Checks requirements using `check-reqs` and then starts the connector using the `start` script
- `watch`: Checks requirements using `check-reqs` and then starts the connector using the `watch` script

There is also a `read-package-script.js` file. This is used to read the `scripts` defined in the user's `package.json` and extract them. `start` and `watch` use this to get the command to use to start/watch from the `package.json`. This is done using this NodeJS script file in order to avoid requiring the user to install `jq`.
`start` and `watch` don't just run `npm run <command>` because npm does not handle signals correctly. The `ddn` CLI will send `SIGTERM` to the script (on *nix systems) when it wants the connector to shut down. `npm` swallows this. So the scripts `exec` the appropriate command directly, ensuring that the node process itself is the one to receive the `SIGTERM` and `npm` isn't involved.

These scripts are copied into the `.hasura-connector` folder in the connector definition tarball, and are referenced in the new `nativeToolchainDefinition` in the `connector-metadata.yaml`.
