### PR TITLE
Fixed functions that return null causing crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes to be included in the next upcoming release
 - Support for NDC Spec v0.1.2 via the NDC TypeScript SDK v4.4.0 ([#29](https://github.com/hasura/ndc-nodejs-lambda/pull/29)).
   - Built-in scalar types that support equality now define it in the NDC schema.
   - Built-in scalar types now have an explicit type representation defined in the NDC schema.
+- Fixed functions that return null causing crashes ([#31](https://github.com/hasura/ndc-nodejs-lambda/pull/31))
 
 ## [1.2.0] - 2024-03-18
 - Improved error messages when unsupported enum types or unions of literal types are found, and allow these types to be used in relaxed types mode ([#17](https://github.com/hasura/ndc-nodejs-lambda/pull/17))

--- a/ndc-lambda-sdk/src/execution.ts
+++ b/ndc-lambda-sdk/src/execution.ts
@@ -170,10 +170,10 @@ function coerceArgumentValue(value: unknown, type: schema.TypeReference, valuePa
 async function invokeFunction(func: Function, preparedArgs: unknown[], functionName: string): Promise<unknown> {
   try {
     return await withActiveSpan(tracer, `Function: ${functionName}`, async () => {
-      const result = func.apply(undefined, preparedArgs);
+      const result: unknown = func.apply(undefined, preparedArgs);
       // Await the result if it is a promise
-      if (result && typeof result === "object" && 'then' in result && typeof result.then === "function") {
-        return await result;
+      if (result !== null && typeof result === "object" && "then" in result && typeof result.then === "function") {
+        return await (result as PromiseLike<unknown>);
       }
       return result;
     }, { [FUNCTION_NAME_SPAN_ATTR_NAME]: functionName });

--- a/ndc-lambda-sdk/src/execution.ts
+++ b/ndc-lambda-sdk/src/execution.ts
@@ -172,7 +172,7 @@ async function invokeFunction(func: Function, preparedArgs: unknown[], functionN
     return await withActiveSpan(tracer, `Function: ${functionName}`, async () => {
       const result = func.apply(undefined, preparedArgs);
       // Await the result if it is a promise
-      if (typeof result === "object" && 'then' in result && typeof result.then === "function") {
+      if (result && typeof result === "object" && 'then' in result && typeof result.then === "function") {
         return await result;
       }
       return result;


### PR DESCRIPTION
This function that checks for a Promise breaks when a non-async function returns `null`, as `typeof null === "object"`. This adds a basic truthiness check.