### PR TITLE
Update TypeScript SDK to v4.5.0 and prepare v1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 This changelog documents the changes between release versions.
 
 > [!IMPORTANT]
-> Hasura DDN Alpha users should use 0.x versions of the `ndc-lambda-sdk`. v1.x versions of the `ndc-lambda-sdk` support the forthcoming Hasura DDN Beta.
+> Hasura DDN Alpha users should use 0.x versions of the `ndc-lambda-sdk`. v1.x versions of the `ndc-lambda-sdk` support the Hasura DDN Beta.
 
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+## [1.3.0] - 2024-04-17
 - Fixed watch mode not reloading after files with compiler errors are changed [#27](https://github.com/hasura/ndc-nodejs-lambda/pull/27)
 - Fixed functions that are imported then re-exported causing a crash [#28](https://github.com/hasura/ndc-nodejs-lambda/pull/28)
 - Support for NDC Spec v0.1.2 via the NDC TypeScript SDK v4.4.0 ([#29](https://github.com/hasura/ndc-nodejs-lambda/pull/29)).
@@ -14,6 +15,7 @@ Changes to be included in the next upcoming release
   - Built-in scalar types now have an explicit type representation defined in the NDC schema.
 - Fixed functions that return null causing crashes ([#31](https://github.com/hasura/ndc-nodejs-lambda/pull/31))
 - Added support for native connector packaging ([#30](https://github.com/hasura/ndc-nodejs-lambda/pull/30))
+- [b3 (zipkin)](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3#b3-formats) OpenTelemetry trace propagation support via the NDC TypeScript SDK v4.5.0 ([#32](https://github.com/hasura/ndc-nodejs-lambda/pull/31))
 
 ## [1.2.0] - 2024-03-18
 - Improved error messages when unsupported enum types or unions of literal types are found, and allow these types to be used in relaxed types mode ([#17](https://github.com/hasura/ndc-nodejs-lambda/pull/17))

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The Node.js Lambda connector allows you to expose TypeScript functions as NDC functions/procedures for use in your Hasura DDN subgraphs.
 
 > [!IMPORTANT]
-> Hasura DDN Alpha users should use 0.x versions of the `ndc-lambda-sdk`. v1.x versions of the `ndc-lambda-sdk` support the forthcoming Hasura DDN Beta.
+> Hasura DDN Alpha users should use 0.x versions of the `ndc-lambda-sdk`. v1.x versions of the `ndc-lambda-sdk` support the Hasura DDN Beta.
 
 ## How to Use
 First, ensure you have Node.js v20+ installed. Then, create a directory into which you will create your functions using the `hasura-ndc-nodejs-lambda` Yeoman template.

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hasura/ndc-sdk-typescript": "^4.4.0",
+        "@hasura/ndc-sdk-typescript": "^4.5.0",
         "@tsconfig/node20": "^20.1.3",
         "commander": "^11.1.0",
         "cross-spawn": "^7.0.3",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@hasura/ndc-sdk-typescript": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-4.4.0.tgz",
-      "integrity": "sha512-tz4GPO+HmcXm4TvWjqjXjTGv0vTJWqcoydtDA1aiDEqUsUqx/nukfdwtaQM7CQa/Knv8Ov7FqMAMs7IEFQiAWw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-4.5.0.tgz",
+      "integrity": "sha512-yRkezh73OZ5BrTFusueEkl0kifWs/oHmkyVb3iUAakVK4obYHLWQrpYOaPfPqA3RysO19opnJcxq6Y07TEh6Hg==",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@opentelemetry/api": "^1.7.0",

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-lambda-sdk",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hasura/ndc-sdk-typescript": "^4.5.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "SDK that can automatically expose TypeScript functions as Hasura NDC functions/procedures",
   "author": "Hasura",
   "license": "Apache-2.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -30,7 +30,7 @@
     "url": "git+https://github.com/hasura/ndc-nodejs-lambda.git"
   },
   "dependencies": {
-    "@hasura/ndc-sdk-typescript": "^4.4.0",
+    "@hasura/ndc-sdk-typescript": "^4.5.0",
     "@tsconfig/node20": "^20.1.3",
     "commander": "^11.1.0",
     "cross-spawn": "^7.0.3",

--- a/yeoman-generator/package-lock.json
+++ b/yeoman-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generator-hasura-ndc-nodejs-lambda",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generator-hasura-ndc-nodejs-lambda",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "pacote": "^17.0.5",
         "semver": "^7.5.4",

--- a/yeoman-generator/package-lock.json
+++ b/yeoman-generator/package-lock.json
@@ -4515,9 +4515,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/yeoman-generator/package.json
+++ b/yeoman-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-hasura-ndc-nodejs-lambda",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Yeoman generator for Hasura DDN ndc-nodejs-lambda connectors",
   "files": [
     "generators"


### PR DESCRIPTION
This PR updates the TS SDK to v4.5.0 (to get [OpenTelemetry improvements](https://github.com/hasura/ndc-sdk-typescript/pull/28)), and prepares the connector for the v1.3.0 release.