### PR TITLE
Add a default .gitignore that ignores node_modules in the connector template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+- Added a default .gitignore that ignores node_modules in the connector template ([#34](https://github.com/hasura/ndc-nodejs-lambda/pull/34))
+
 ## [1.4.0] - 2024-05-08
 - Removed type inference recursion limit ([#33](https://github.com/hasura/ndc-nodejs-lambda/pull/33)). This enables the use of very nested object graphs.
 - Updated the NDC TypeScript SDK to v4.6.0 ([#33](https://github.com/hasura/ndc-nodejs-lambda/pull/33)).

--- a/README.md
+++ b/README.md
@@ -279,8 +279,6 @@ export async function test(statusCode: number): Promise<string> {
 Non-readonly functions are not invoked in parallel within the same mutation request to the connector, so it is invalid to use the @paralleldegree JSDoc tag on those functions.
 
 ### Documentation
-*Note: this feature is still in development.*
-
 JSDoc comments on your functions and types are used to provide descriptions for types exposed in your GraphQL schema. For example:
 
 ```typescript

--- a/connector-definition/Makefile
+++ b/connector-definition/Makefile
@@ -25,7 +25,8 @@ dist/.hasura-connector/Dockerfile: Dockerfile dist/.hasura-connector $(RELEASE_V
 dist/.hasura-connector/.dockerignore: .dockerignore dist/.hasura-connector
 	cp -f .dockerignore dist/.hasura-connector/
 
-template_files := $(filter-out %/package.json,$(wildcard template/*))
+# The .[!.]* includes hidden files (ie. the .gitignore file)
+template_files := $(filter-out %/package.json,$(wildcard template/* template/.[!.]*))
 dist_template_files := $(patsubst template/%,dist/%,$(template_files))
 
 $(dist_template_files): $(template_files)

--- a/connector-definition/template/.gitignore
+++ b/connector-definition/template/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
Simply adds a `.gitignore` file to the connector definition template files so that new connectors get their node_modules directory gitignored by default.