### PR TITLE
Update to TS SDK v5, support biginteger representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This changelog documents the changes between release versions.
 Changes to be included in the next upcoming release
 
 - Added a default .gitignore that ignores node_modules in the connector template ([#34](https://github.com/hasura/ndc-nodejs-lambda/pull/34))
+- Updated to NDC TypeScript SDK to v5.0.0 ([#35](https://github.com/hasura/ndc-nodejs-lambda/pull/35))
+  - The BigInt scalar type now uses the biginteger type representation
 
 ## [1.4.0] - 2024-05-08
 - Removed type inference recursion limit ([#33](https://github.com/hasura/ndc-nodejs-lambda/pull/33)). This enables the use of very nested object graphs.

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hasura/ndc-sdk-typescript": "^4.6.0",
+        "@hasura/ndc-sdk-typescript": "^5.0.0",
         "@tsconfig/node20": "^20.1.3",
         "commander": "^11.1.0",
         "cross-spawn": "^7.0.3",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@hasura/ndc-sdk-typescript": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-4.6.0.tgz",
-      "integrity": "sha512-2WkDrzqCFOMm4hJafZ7+H0ABhDHjIFaU3xi1wkAm8fQM11GveSlI5cpQ2SM38U8a9sbq8qI8UPmeony3niIB/w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-5.0.0.tgz",
+      "integrity": "sha512-+WfeQBhJvagAYLGknowTCdjHSjOVCOzhVIzXroHXut17p1/ger8KaUF2MUk8F5XU5nlVL9dIOxb4ZRSBy58dZg==",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@opentelemetry/api": "^1.8.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -30,7 +30,7 @@
     "url": "git+https://github.com/hasura/ndc-nodejs-lambda.git"
   },
   "dependencies": {
-    "@hasura/ndc-sdk-typescript": "^4.6.0",
+    "@hasura/ndc-sdk-typescript": "^5.0.0",
     "@tsconfig/node20": "^20.1.3",
     "commander": "^11.1.0",
     "cross-spawn": "^7.0.3",

--- a/ndc-lambda-sdk/src/connector.ts
+++ b/ndc-lambda-sdk/src/connector.ts
@@ -67,10 +67,11 @@ export function createConnector(options: ConnectorOptions): sdk.Connector<Config
 
     getCapabilities: function (configuration: Configuration): sdk.CapabilitiesResponse {
       return {
-        version: "0.1.2",
+        version: "0.1.3",
         capabilities: {
           query: {
-            variables: {}
+            variables: {},
+            nested_fields: {},
           },
           mutation: {},
         }

--- a/ndc-lambda-sdk/src/schema.ts
+++ b/ndc-lambda-sdk/src/schema.ts
@@ -298,7 +298,7 @@ function convertBuiltInScalarTypeIntoSdkSchemaType(typeName: BuiltInScalarTypeNa
       comparison_operators: { "_eq": { type: "equal" } },
     };
     case BuiltInScalarTypeName.BigInt: return {
-      representation: { type: "int64" }, // NDC doesn't have a good representation for this type as at v0.1.2, so this is the best representation in the meantime
+      representation: { type: "biginteger" },
       aggregate_functions: {},
       comparison_operators: { "_eq": { type: "equal" } },
     };

--- a/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
+++ b/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
@@ -233,7 +233,7 @@ describe("ndc schema", function() {
           }
         },
         "BigInt": {
-          representation: { type: "int64" },
+          representation: { type: "biginteger" },
           aggregate_functions: {},
           comparison_operators: {
             "_eq": { type: "equal" }


### PR DESCRIPTION
This PR updates the TS SDK to v5.0.0, which brings biginteger type representation support. This is then used to annotate the BigInt scalar type.