### PR TITLE
Add dotenv-cli as a dev-dependency to help run the connector with .env files, and update README instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes to be included in the next upcoming release
 - Added a default .gitignore that ignores node_modules in the connector template ([#34](https://github.com/hasura/ndc-nodejs-lambda/pull/34))
 - Updated to NDC TypeScript SDK to v5.0.0 ([#35](https://github.com/hasura/ndc-nodejs-lambda/pull/35))
   - The BigInt scalar type now uses the biginteger type representation
+- Added `dotenv-cli` to the dev dependencies of the connector's default package.json to help with using .env files ([#36](https://github.com/hasura/ndc-nodejs-lambda/pull/36))
 
 ## [1.4.0] - 2024-05-08
 - Removed type inference recursion limit ([#33](https://github.com/hasura/ndc-nodejs-lambda/pull/33)). This enables the use of very nested object graphs.

--- a/connector-definition/template/package.json
+++ b/connector-definition/template/package.json
@@ -9,5 +9,8 @@
   },
   "dependencies": {
     "@hasura/ndc-lambda-sdk": "*"
+  },
+  "devDependencies": {
+    "dotenv-cli": "^7.4.2"
   }
 }

--- a/yeoman-generator/src/app/index.ts
+++ b/yeoman-generator/src/app/index.ts
@@ -91,6 +91,9 @@ export default class extends Generator {
       },
       "dependencies": {
         "@hasura/ndc-lambda-sdk": packageManifest.version
+      },
+      "devDependencies": {
+        "dotenv-cli": "^7.4.2"
       }
     })
   }


### PR DESCRIPTION
This PR adds the `dotenv-cli` package to the `devDependencies` of the default package.json so that users can easily run the connector with a .env file (as they will in the new local dev DX) by running `npx dotenv -e .env.local -- npm run watch`.

It also updates the README with instructions on how to use the connector using the new local dev DX in the `ddn` CLI.