### PR TITLE
Upgrade TS SDK to v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+## [1.6.0] - 2024-08-08
+- Updated the NDC TypeScript SDK to v6.0.0 ([#39](https://github.com/hasura/ndc-nodejs-lambda/pull/39))
+  - The `/health` endpoint is now unauthenticated
+
 ## [1.5.0] - 2024-07-30
 - Updated the NDC TypeScript SDK to v5.2.0 ([#38](https://github.com/hasura/ndc-nodejs-lambda/pull/38))
   - The connector now listens on both ipv4 and ipv6 interfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes to be included in the next upcoming release
 ## [1.6.0] - 2024-08-08
 - Updated the NDC TypeScript SDK to v6.0.0 ([#39](https://github.com/hasura/ndc-nodejs-lambda/pull/39))
   - The `/health` endpoint is now unauthenticated
+- Updated TypeScript to v5.5.4 ([#39](https://github.com/hasura/ndc-nodejs-lambda/pull/39))
 
 ## [1.5.0] - 2024-07-30
 - Updated the NDC TypeScript SDK to v5.2.0 ([#38](https://github.com/hasura/ndc-nodejs-lambda/pull/38))

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-lambda-sdk",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hasura/ndc-sdk-typescript": "^5.2.0",
-        "@tsconfig/node20": "^20.1.3",
+        "@hasura/ndc-sdk-typescript": "^6.0.0",
+        "@tsconfig/node20": "^20.1.4",
         "commander": "^11.1.0",
         "cross-spawn": "^7.0.3",
         "p-limit": "^3.1.0",
         "ts-api-utils": "^1.3.0",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^5.4.3"
+        "typescript": "^5.5.4"
       },
       "bin": {
         "ndc-lambda-sdk": "bin/index.js"
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@hasura/ndc-sdk-typescript": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-5.2.0.tgz",
-      "integrity": "sha512-XLfFGC5bz0En5J3JZzouRl5bS/qfvJrTNJA6sq7hQ09gk0qSNNCzaKHg0UZK6a1HeoOCsfAW4/S4633sWn9HjQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-6.0.0.tgz",
+      "integrity": "sha512-iLC7IAh2rsW7iyt6swLyOpk0zL32d5LeGN+KSJNJEO6n8eXKsjQpJZBsqKEYOyGcfSlbNqTC1qsobbtwe7Bjyw==",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@opentelemetry/api": "^1.8.0",
@@ -944,9 +944,9 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@tsconfig/node20": {
-      "version": "20.1.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.3.tgz",
-      "integrity": "sha512-XeWn6Gms5MaQWdj+C4fuxuo/Icy8ckh+BwAIijhX2LKRHHt1OuctLLLlB0F4EPi55m2IUJNTnv8FH9kSBI7Ogw=="
+      "version": "20.1.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
+      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg=="
     },
     "node_modules/@types/chai": {
       "version": "4.3.11",
@@ -2999,9 +2999,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "SDK that can automatically expose TypeScript functions as Hasura NDC functions/procedures",
   "author": "Hasura",
   "license": "Apache-2.0",
@@ -30,15 +30,15 @@
     "url": "git+https://github.com/hasura/ndc-nodejs-lambda.git"
   },
   "dependencies": {
-    "@hasura/ndc-sdk-typescript": "^5.2.0",
-    "@tsconfig/node20": "^20.1.3",
+    "@hasura/ndc-sdk-typescript": "^6.0.0",
+    "@tsconfig/node20": "^20.1.4",
     "commander": "^11.1.0",
     "cross-spawn": "^7.0.3",
     "p-limit": "^3.1.0",
     "ts-api-utils": "^1.3.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.4.3"
+    "typescript": "^5.5.4"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",

--- a/ndc-lambda-sdk/src/connector.ts
+++ b/ndc-lambda-sdk/src/connector.ts
@@ -65,16 +65,13 @@ export function createConnector(options: ConnectorOptions): sdk.Connector<Config
       return {};
     },
 
-    getCapabilities: function (configuration: Configuration): sdk.CapabilitiesResponse {
+    getCapabilities: function (configuration: Configuration): sdk.Capabilities {
       return {
-        version: "0.1.5",
-        capabilities: {
-          query: {
-            variables: {},
-            nested_fields: {},
-          },
-          mutation: {},
-        }
+        query: {
+          variables: {},
+          nested_fields: {},
+        },
+        mutation: {},
       };
     },
 
@@ -96,10 +93,6 @@ export function createConnector(options: ConnectorOptions): sdk.Connector<Config
 
     mutationExplain: function (configuration: Configuration, state: State, request: sdk.MutationRequest): Promise<sdk.ExplainResponse> {
       throw new Error("Function not implemented.");
-    },
-
-    healthCheck: async function (configuration: Configuration, state: State): Promise<undefined> {
-      return undefined;
     },
 
     fetchMetrics: async function (configuration: Configuration, state: State): Promise<undefined> {


### PR DESCRIPTION
This PR upgrades the NDC TypeScript SDK to v6.0.0. This makes the `/health` endpoint unauthenticated, and also automatically handles the NDC version in capabilities.

I also updated TypeScript to the latest available version, which bumps it from a 5.4 release to a 5.5 release.