### PR TITLE
New type for representing the Supergraph connection details

### DIFF
--- a/ndc-lambda-sdk/src/execution.ts
+++ b/ndc-lambda-sdk/src/execution.ts
@@ -202,6 +202,13 @@ export function getErrorDetails(error: Error): ErrorDetails {
   }
 }
 
+// NOTE: This should be provided by the NDC SDK types at some point
+// then this can be replaced and won't have to be kept in sync
+// manually with the engine changes.
+export type Supergraph = {
+  endpoint: string
+}
+
 function buildCausalStackTrace(error: Error): string {
   let seenErrs: Error[] = [];
   let currErr: Error | undefined = error;

--- a/ndc-lambda-sdk/src/schema.ts
+++ b/ndc-lambda-sdk/src/schema.ts
@@ -189,6 +189,10 @@ export class JSONValue {
     return this.#value;
   }
 
+  get toJSON(): unknown {
+    return this.#value;
+  }
+
   /**
    * @internal
    */

--- a/ndc-lambda-sdk/src/sdk.ts
+++ b/ndc-lambda-sdk/src/sdk.ts
@@ -1,4 +1,4 @@
 export { JSONValue } from "./schema";
 export { ConnectorError, BadRequest, Forbidden, Conflict, UnprocessableContent, InternalServerError, NotSupported, BadGateway } from "@hasura/ndc-sdk-typescript";
 export { withActiveSpan, USER_VISIBLE_SPAN_ATTRIBUTE } from "@hasura/ndc-sdk-typescript/instrumentation"
-export { ErrorDetails, getErrorDetails } from "./execution";
+export { ErrorDetails, getErrorDetails, Supergraph } from "./execution";


### PR DESCRIPTION
Also added toJSON method to JSONValue to have JSON.stringify work correctly.

This came up during the Supergraph client work.