### PR TITLE
Add documentationPage to the connector metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+- Added `documentationPage` to the connector metadata to enable the `ddn` CLI to suggest documentation to users ([#41](https://github.com/hasura/ndc-nodejs-lambda/pull/41))
+
 ## [1.6.0] - 2024-08-08
 - Updated the NDC TypeScript SDK to v6.0.0 ([#39](https://github.com/hasura/ndc-nodejs-lambda/pull/39))
   - The `/health` endpoint is now unauthenticated

--- a/connector-definition/connector-metadata.yaml
+++ b/connector-definition/connector-metadata.yaml
@@ -24,3 +24,4 @@ dockerComposeWatch:
   - path: ./
     target: /functions
     action: sync+restart
+documentationPage: https://hasura.info/nodejs-getting-started


### PR DESCRIPTION
This adds the `documentationPage` url to the connector metadata file as per this RFC: https://github.com/hasura/ndc-hub/pull/260