### PR TITLE
Add multi-platform docker image build

### DIFF
--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -74,20 +74,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: docker-metadata
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}
-      - uses: docker/build-push-action@v5
+
+      - uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+- Added multi-platform support to the `hasura/ndc-nodejs-lambda` docker image. It now supports both linux/amd64 and linux/arm64 platforms ([#42](https://github.com/hasura/ndc-nodejs-lambda/pull/42))
+
 ## [1.6.0] - 2024-08-08
 - Updated the NDC TypeScript SDK to v6.0.0 ([#39](https://github.com/hasura/ndc-nodejs-lambda/pull/39))
   - The `/health` endpoint is now unauthenticated


### PR DESCRIPTION
This PR updates the CI build so that the connector's base docker image build is built for both amd64 and arm64. This should help it run more efficiently on Apple Silicon machines which use ARM chips.