### PR TITLE
Export connector module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+### Added
+- Exported the `@hasura/ndc-lambda-sdk/connector` module to make it easier to build entirely new connectors that extend the existing functionality provided by the SDK ([#45](https://github.com/hasura/ndc-nodejs-lambda/pull/45))
+
 ## [1.8.0] - 2024-09-20
 - Updated the NDC TypeScript SDK to v7.0.0 ([#44](https://github.com/hasura/ndc-nodejs-lambda/pull/44))
   - Added support for exporting OpenTelemetry traces and metrics over GRPC. A new environment variable `OTEL_EXPORTER_OTLP_PROTOCOL` lets you switch between `http/protobuf` and `grpc`.

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -2221,9 +2221,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2820,19 +2820,14 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/light-my-request": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.11.0.tgz",
-      "integrity": "sha512-qkFCeloXCOMpmEdZ/MV91P8AT4fjwFXWaAFz3lUeStM8RcoM1ks4J/F8r1b3r6y/H4u3ACEJ1T+Gv5bopj7oDA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.14.0.tgz",
+      "integrity": "sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==",
       "dependencies": {
-        "cookie": "^0.5.0",
-        "process-warning": "^2.0.0",
+        "cookie": "^0.7.0",
+        "process-warning": "^3.0.0",
         "set-cookie-parser": "^2.4.1"
       }
-    },
-    "node_modules/light-my-request/node_modules/process-warning": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.2.tgz",
-      "integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA=="
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -18,7 +18,8 @@
   ],
   "exports": {
     ".": "./dist/src/sdk.js",
-    "./host": "./dist/src/host.js"
+    "./host": "./dist/src/host.js",
+    "./connector": "./dist/src/connector.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
By exporting the connector module we make it easier to build entirely new connectors that extend the existing functionality provided by this SDK.