### PR TITLE
Add support for connector upgrades

### DIFF
--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -94,9 +94,19 @@ jobs:
         with:
           images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}
 
+      - name: Get npm package version
+        id: get-npm-package-version
+        run: |
+          PACKAGE_VERSION=`npm version | sed -rn "2 s/.*: '([^']*)'.*/\1/g; 2 p"`
+          echo "package_version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
+        shell: bash
+        working-directory: ./ndc-lambda-sdk
+
       - uses: docker/build-push-action@v6
         with:
           context: .
+          build-args: |
+            CONNECTOR_VERSION=${{ steps.get-npm-package-version.outputs.package_version }}
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker-metadata.outputs.tags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+### Added
+- The connector now supports being upgraded with the forthcoming `ddn connector upgrade` command ([#51](https://github.com/hasura/ndc-nodejs-lambda/pull/51))
+
 ## [1.10.0] - 2024-11-21
-- The connector now exits during startup if there are compiler errors in the functions code. The compiler errors are printed to stderr. Previously the connector would print the errors and start "successfully", but with an empty schema. The new behaviour ensures that when the connector is used with `ddn connector introspect`, `ddn` is aware that a problem has occurred (because the connector fails to start) and will prompt the user to print the logs to see the compiler errors.
+- The connector now exits during startup if there are compiler errors in the functions code. The compiler errors are printed to stderr. Previously the connector would print the errors and start "successfully", but with an empty schema. The new behaviour ensures that when the connector is used with `ddn connector introspect`, `ddn` is aware that a problem has occurred (because the connector fails to start) and will prompt the user to print the logs to see the compiler errors. ([#50](https://github.com/hasura/ndc-nodejs-lambda/pull/50))
 
 ## [1.9.0] - 2024-10-24
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:20-alpine
+ARG CONNECTOR_VERSION
 
 RUN apk add jq curl
 
 COPY /docker /scripts
+RUN : "${CONNECTOR_VERSION:?Connector version must be set}"
+RUN echo ${CONNECTOR_VERSION} > /scripts/CONNECTOR_VERSION
 
 COPY /functions /functions
 RUN /scripts/package-restore.sh

--- a/connector-definition/Makefile
+++ b/connector-definition/Makefile
@@ -17,6 +17,7 @@ dist dist/.hasura-connector:
 
 dist/.hasura-connector/connector-metadata.yaml: connector-metadata.yaml dist
 	cp -f connector-metadata.yaml dist/.hasura-connector
+	sed -i -E 's/\{\{VERSION\}\}/$(RELEASE_VERSION)/g' dist/.hasura-connector/connector-metadata.yaml
 
 dist/.hasura-connector/Dockerfile: Dockerfile dist/.hasura-connector $(RELEASE_VERSION_DEP)
 	cp -f Dockerfile dist/.hasura-connector/

--- a/connector-definition/connector-metadata.yaml
+++ b/connector-definition/connector-metadata.yaml
@@ -11,7 +11,11 @@ nativeToolchainDefinition:
       bash: ./watch.sh
       powershell: ./watch.ps1
 supportedEnvironmentVariables: []
-commands: {}
+commands:
+  upgradeConfiguration:
+    type: Dockerized
+    dockerImage: ghcr.io/hasura/ndc-nodejs-lambda:v{{VERSION}}
+    dockerCommand: ["/scripts/upgrade-connector.sh"]
 dockerComposeWatch:
   # Rebuild the container if a new package restore is required because package[-lock].json changed
   - path: package.json

--- a/docker/upgrade-connector.sh
+++ b/docker/upgrade-connector.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+set -eu -o pipefail
+
+connector_path="${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH:-/functions}"
+target_connector_version="$(cat /scripts/CONNECTOR_VERSION)"
+
+rm -rf /tmp/connector-upgrade
+mkdir /tmp/connector-upgrade
+
+# We copy the package.json and package-lock.json to a temporary directory
+# so that we can upgrade the @hasura/ndc-lambda-sdk package without touching the
+# existing node_modules directory. This is because the existing node_modules directory
+# may have been installed on a different platform since it is being volume mounted
+# into a Linux container
+echo -n "Copying package.json, package-lock.json to a temporary location for upgrade... "
+cd "$connector_path"
+cp "package.json" "package-lock.json" /tmp/connector-upgrade/
+echo "done"
+
+
+cd /tmp/connector-upgrade
+
+set +e
+existing_connector_version=$(jq '.dependencies["@hasura/ndc-lambda-sdk"]' -r package.json)
+exit_status=$?
+if [ $exit_status -ne 0 ]; then
+  echo "Unable to read the @hasura/ndc-lambda-sdk version from your package.json"
+  echo "Please manually upgrade the @hasura/ndc-lambda-sdk package in your package.json to version $target_connector_version"
+  exit 1
+fi
+
+if [ $existing_connector_version = "null" ]; then
+  # This is very strange, their package.json must have the SDK installed but doesn't
+  # We'll roll with it and just install the package
+  echo "Missing the @hasura/ndc-lambda-sdk package in your package.json. Installing version $target_connector_version"
+else
+  echo "Upgrading @hasura/ndc-lambda-sdk package from version $existing_connector_version to version $target_connector_version"
+fi
+
+npm install "@hasura/ndc-lambda-sdk@$target_connector_version" --save-exact --no-update-notifier
+exit_status=$?
+set -e
+
+if [ $exit_status -ne 0 ]; then
+  echo "Failed to upgrade @hasura/ndc-lambda-sdk package to version $target_connector_version"
+  echo "Please manually upgrade the @hasura/ndc-lambda-sdk package in your package.json to version $target_connector_version"
+  exit 1
+fi
+
+# We overwrite the existing file contents instead of copying because this causes the existing
+# file permissions/ownership to be retained, which is important since the container is likely
+# running as a different user to what's running on the docker host machine
+echo -n "Copying upgraded package.json, package-lock.json back to connector files... "
+cat package.json > "$connector_path/package.json"
+cat package-lock.json > "$connector_path/package-lock.json"
+echo "done"
+
+echo "Successfully upgraded @hasura/ndc-lambda-sdk package to version $target_connector_version"
+echo "You may need to run 'npm install' to install the new dependencies locally"

--- a/docker/upgrade-connector.sh
+++ b/docker/upgrade-connector.sh
@@ -4,21 +4,7 @@ set -eu -o pipefail
 connector_path="${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH:-/functions}"
 target_connector_version="$(cat /scripts/CONNECTOR_VERSION)"
 
-rm -rf /tmp/connector-upgrade
-mkdir /tmp/connector-upgrade
-
-# We copy the package.json and package-lock.json to a temporary directory
-# so that we can upgrade the @hasura/ndc-lambda-sdk package without touching the
-# existing node_modules directory. This is because the existing node_modules directory
-# may have been installed on a different platform since it is being volume mounted
-# into a Linux container
-echo -n "Copying package.json, package-lock.json to a temporary location for upgrade... "
 cd "$connector_path"
-cp "package.json" "package-lock.json" /tmp/connector-upgrade/
-echo "done"
-
-
-cd /tmp/connector-upgrade
 
 set +e
 existing_connector_version=$(jq '.dependencies["@hasura/ndc-lambda-sdk"]' -r package.json)
@@ -37,6 +23,9 @@ else
   echo "Upgrading @hasura/ndc-lambda-sdk package from version $existing_connector_version to version $target_connector_version"
 fi
 
+# We do a --package-lock-only because we don't want to change the node_modules directory.
+# This is because the existing node_modules directory  may have been installed on a
+# different platform since it is being volume mounted into a Linux container
 npm install "@hasura/ndc-lambda-sdk@$target_connector_version" --save-exact --no-update-notifier --package-lock-only
 exit_status=$?
 set -e
@@ -46,14 +35,6 @@ if [ $exit_status -ne 0 ]; then
   echo "Please manually upgrade the @hasura/ndc-lambda-sdk package in your package.json to version $target_connector_version"
   exit 1
 fi
-
-# We overwrite the existing file contents instead of copying because this causes the existing
-# file permissions/ownership to be retained, which is important since the container is likely
-# running as a different user to what's running on the docker host machine
-echo -n "Copying upgraded package.json, package-lock.json back to connector files... "
-cat package.json > "$connector_path/package.json"
-cat package-lock.json > "$connector_path/package-lock.json"
-echo "done"
 
 echo "Successfully upgraded @hasura/ndc-lambda-sdk package to version $target_connector_version"
 echo "You may need to run 'npm install' to install the new dependencies locally"

--- a/docker/upgrade-connector.sh
+++ b/docker/upgrade-connector.sh
@@ -37,7 +37,7 @@ else
   echo "Upgrading @hasura/ndc-lambda-sdk package from version $existing_connector_version to version $target_connector_version"
 fi
 
-npm install "@hasura/ndc-lambda-sdk@$target_connector_version" --save-exact --no-update-notifier
+npm install "@hasura/ndc-lambda-sdk@$target_connector_version" --save-exact --no-update-notifier --package-lock-only
 exit_status=$?
 set -e
 


### PR DESCRIPTION
This PR adds support for connector upgrades via the forthcoming `ddn connector upgrade` command.

This works by having the `ddn` CLI run the docker image with the connector directory mounted and running the new `/scripts/upgrade-connector.sh` script. This script copies the user's package.json and package-lock.json files and performs an npm install on them to upgrade the SDK package. It then overwrites their files with the updated versions.

Fixes ENG-1119