### PR TITLE
Update TypeScript version and npm in the Docker image and bump version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[Makefile]
+indent_style = tab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+## [1.12.0] - 2025-03-21
+- Updated to use [TypeScript v5.8.2](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/) ([#53](https://github.com/hasura/ndc-nodejs-lambda/pull/53))
+- Updated `cross-spawn` dependency to resolve [security vulnerability](https://www.cve.org/CVERecord?id=CVE-2024-21538) ([#53](https://github.com/hasura/ndc-nodejs-lambda/pull/53))
+
 ## [1.11.0] - 2025-01-22
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:20-alpine
 ARG CONNECTOR_VERSION
 
+RUN npm update -g npm
 RUN apk add jq curl
 
 COPY /docker /scripts

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-lambda-sdk",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hasura/ndc-sdk-typescript": "^7.0.0",
         "@hasura/ts-node-dev": "^2.1.0",
         "@tsconfig/node20": "^20.1.4",
         "commander": "^11.1.0",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.6",
         "p-limit": "^3.1.0",
-        "ts-api-utils": "^1.3.0",
+        "ts-api-utils": "^2.1.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.7.3"
+        "typescript": "^5.8.2"
       },
       "bin": {
         "ndc-lambda-sdk": "bin/index.js"
@@ -3710,14 +3710,14 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-node": {
@@ -3783,9 +3783,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "SDK that can automatically expose TypeScript functions as Hasura NDC functions/procedures",
   "author": "Hasura",
   "license": "Apache-2.0",
@@ -35,11 +35,11 @@
     "@hasura/ts-node-dev": "^2.1.0",
     "@tsconfig/node20": "^20.1.4",
     "commander": "^11.1.0",
-    "cross-spawn": "^7.0.3",
+    "cross-spawn": "^7.0.6",
     "p-limit": "^3.1.0",
-    "ts-api-utils": "^1.3.0",
+    "ts-api-utils": "^2.1.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.8.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",


### PR DESCRIPTION
This PR updates the TypeScript version used to v5.8.2, and also updates the npm version installed inside the Docker container to the latest version at the time of Docker build. This is to fix a transitive [security vulnerability](https://www.cve.org/CVERecord?id=CVE-2024-21538) in npm's version of cross-spawn. The minimum required version of cross-spawn was also updated in the SDK's package.json.

We also update `ts-api-utils`, just to keep it up to date since we're updating the TS compiler.

The package version has been bumped to v1.12.0