### PR TITLE
Add gokakashi scanning in CI

### DIFF
--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -88,8 +88,9 @@ jobs:
               }
             }
 
-      - name: debug
+      - name: Fix containerd socket permissions
         run: |
+          sudo chgrp docker /run/containerd/containerd.sock
           id
           sudo ls -al /var/run/docker.sock
           sudo ls -al /run/containerd/

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -90,9 +90,9 @@ jobs:
 
       - name: debug
         run: |
-          ls -al /run/containerd/
-          ls -al
           id
+          sudo ls -al /var/run/docker.sock
+          sudo ls -al /run/containerd/
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -134,13 +134,6 @@ jobs:
         run: |
           ctr images import --base-name ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }} --digests --all-platforms /tmp/image.tar
 
-      - name: Debug docker image
-        run: |
-          echo "-- Docker Images --"
-          docker image ls
-          echo "-- containerd Images --"
-          ctr images ls
-
       - name: Get first docker tag for gokakashi
         id: first-docker-tag
         run: |
@@ -160,6 +153,12 @@ jobs:
           cf_client_secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           interval: 10
           retries: 8
+
+      - name: Upload Trivy report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-report
+          path: /tmp/trivy-report-*.json
 
       - name: Push docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -112,6 +112,26 @@ jobs:
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}
 
+      - name: Get first docker tag for gokakashi
+        id: first-docker-tag
+        run: |
+          FIRST_TAG=$(echo "${{ steps.docker-metadata.outputs.tags }}" | head -n 1)
+          echo "First docker tag: $FIRST_TAG"
+          echo "tag=$FIRST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Scan docker image with gokakashi
+        uses: shinobistack/gokakashi-action@v0.1.1
+        with:
+          image: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ steps.first-docker-tag.outputs.tag }}
+          labels: agentKey=${{ github.run_id }}
+          policy: ci-platform
+          server: https://gokakashi-server.hasura-app.io
+          token: ${{ secrets.GOKAKASHI_API_TOKEN }}
+          cf_client_id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf_client_secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+          interval: 10
+          retries: 8
+
   release-connector:
     name: Release connector
     defaults:

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -132,6 +132,9 @@ jobs:
 
       - name: Debug docker image
         run: |
+          echo "-- Docker Images --"
+          docker images ls
+          echo "-- containerd Images --"
           ctr images ls
 
       - name: Get first docker tag for gokakashi

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -122,7 +122,7 @@ jobs:
       - name: Scan docker image with gokakashi
         uses: shinobistack/gokakashi-action@v0.1.1
         with:
-          image: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ steps.first-docker-tag.outputs.tag }}
+          image: ${{ steps.first-docker-tag.outputs.tag }}
           labels: agentKey=${{ github.run_id }}
           policy: ci-platform
           server: https://gokakashi-server.hasura-app.io

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -133,7 +133,7 @@ jobs:
       - name: Debug docker image
         run: |
           echo "-- Docker Images --"
-          docker images ls
+          docker image ls
           echo "-- containerd Images --"
           ctr images ls
 

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -75,6 +75,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up containerd
+        uses: crazy-max/ghaction-setup-containerd@v3
+
+      - name: Set up Docker with containerd
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -102,15 +102,16 @@ jobs:
         shell: bash
         working-directory: ./ndc-lambda-sdk
 
-      - uses: docker/build-push-action@v6
+      - name: Build docker image
+        uses: docker/build-push-action@v6
         with:
           context: .
           build-args: |
             CONNECTOR_VERSION=${{ steps.get-npm-package-version.outputs.package_version }}
-          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}
+          load: true # Load the image into Docker so gokakashi can scan it
 
       - name: Get first docker tag for gokakashi
         id: first-docker-tag
@@ -131,6 +132,18 @@ jobs:
           cf_client_secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           interval: 10
           retries: 8
+
+      - name: Push docker image
+        uses: docker/build-push-action@v6
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          context: .
+          build-args: |
+            CONNECTOR_VERSION=${{ steps.get-npm-package-version.outputs.package_version }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.docker-metadata.outputs.tags }}
+          labels: ${{ steps.docker-metadata.outputs.labels }}
+          push: true
 
   release-connector:
     name: Release connector

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -88,6 +88,12 @@ jobs:
               }
             }
 
+      - name: debug
+        run: |
+          ls -al /run/containerd/
+          ls -al
+          id
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -91,9 +91,6 @@ jobs:
       - name: Fix containerd socket permissions
         run: |
           sudo chgrp docker /run/containerd/containerd.sock
-          id
-          sudo ls -al /var/run/docker.sock
-          sudo ls -al /run/containerd/
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -132,6 +129,10 @@ jobs:
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}
           load: true # Load the image into Docker so gokakashi can scan it
+
+      - name: Debug docker image
+        run: |
+          ctr images ls
 
       - name: Get first docker tag for gokakashi
         id: first-docker-tag

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -78,16 +78,6 @@ jobs:
       - name: Set up containerd
         uses: crazy-max/ghaction-setup-containerd@v3
 
-      - name: Set up Docker with containerd
-        uses: docker/setup-docker-action@v4
-        with:
-          daemon-config: |
-            {
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
-
       - name: Fix containerd socket permissions
         run: |
           sudo chgrp docker /run/containerd/containerd.sock

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -128,7 +128,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}
-          load: true # Load the image into Docker so gokakashi can scan it
+          outputs: type=oci,dest=/tmp/image.tar # Export the image to a tar so it can be imported into containerd so gokakashi can scan it
+
+      - name: Import docker image into containerd store
+        run: |
+          ctr images import --base-name ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }} --digests --all-platforms /tmp/image.tar
 
       - name: Debug docker image
         run: |


### PR DESCRIPTION
gokakashi will scan the Docker image for vulnerabilities.

Because we build a multi-architecture docker image, we need install containerd (Docker's image store does not handle multiarch images), export our built image to a tar and import it into containerd in order for gokakashi (via Trivy) to scan it. 