### PR TITLE
Update TypeScript, use bash in Docker scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+## [1.15.0] - 2025-05-20
+- Updated to use [TypeScript v5.8.2](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/) ([#53](https://github.com/hasura/ndc-nodejs-lambda/pull/57))
+
 ## [1.14.0] - 2025-05-12
-- Increase `bodyLimit` to 30mb
+- Increase the limit of the size of the request's body to 30 MB ([#56](https://github.com/hasura/ndc-nodejs-lambda/pull/56))
 
 ## [1.13.0] - 2025-03-27
 - Added native toolchain support for connector version upgrading and fixed Dockerized connector version upgrading ([#55](https://github.com/hasura/ndc-nodejs-lambda/pull/55))

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ EXPOSE 8080
 
 HEALTHCHECK --interval=5s --timeout=10s --start-period=1s --retries=3 CMD [ "sh", "-c", "exec curl -f http://localhost:${HASURA_CONNECTOR_PORT:-8080}/health" ]
 
-CMD [ "sh", "/scripts/start.sh" ]
+CMD [ "bash", "/scripts/start.sh" ]

--- a/docker/package-restore.sh
+++ b/docker/package-restore.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eu -o pipefail
 
 cd /functions

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eu -o pipefail
 
 /scripts/package-restore.sh

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eu -o pipefail
 
 # We do a --package-lock-only because we don't want to change the node_modules directory.

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -17,7 +17,7 @@
         "p-limit": "^3.1.0",
         "ts-api-utils": "^2.1.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.2"
+        "typescript": "^5.8.3"
       },
       "bin": {
         "ndc-lambda-sdk": "bin/index.js"
@@ -3783,9 +3783,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-lambda-sdk",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hasura/ndc-sdk-typescript": "^7.1.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "SDK that can automatically expose TypeScript functions as Hasura NDC functions/procedures",
   "author": "Hasura",
   "license": "Apache-2.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -39,7 +39,7 @@
     "p-limit": "^3.1.0",
     "ts-api-utils": "^2.1.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.3"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",


### PR DESCRIPTION
Technically the settings we use in our docker scripts are only supported by alpine's `sh` and not `sh` more broadly. So I'm changing the scripts to explicitly run using bash, which is installed in the container anyway.

The TS version has also been updated to the latest version, 5.8.3.