### PR TITLE
Update NDC TypeScript SDK to v8.2.0 and prepare v1.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 Changes to be included in the next upcoming release
 
+## [1.16.0] - 2025-07-18
+- Updated the NDC TypeScript SDK to v8.2.0 ([#58](https://github.com/hasura/ndc-nodejs-lambda/pull/58))
+  - Updated to support v0.2.0 of the NDC Spec. This is a very large update which adds new features and some breaking changes to the spec.
+  - If the `X-Hasura-NDC-Version` header is sent, the SDK will validate that the connector supports the incoming request's version and reject it if it does not. If no header is sent, no action is taken
+  - Added support for automatically returning compressed responses using gzip or deflate
+- All OpenTelemetry trace spans are now annotated with the TypeScript SDK version (`resource.service.version: "8.2.0"`) and the connector name (`resource.service.connector.name: "ndc-nodejs-lambda"`) and version (`resource.service.connector.version: "1.16.0"`). The connector name and version can be overriden using `HASURA_CONNECTOR_NAME` and `HASURA_CONNECTOR_VERSION` environment variables.
+
 ## [1.15.0] - 2025-05-20
 - Updated to use [TypeScript v5.8.3](https://github.com/microsoft/TypeScript/releases/tag/v5.8.3) ([#57](https://github.com/hasura/ndc-nodejs-lambda/pull/57))
 

--- a/connector-definition/connector-metadata.schema.json
+++ b/connector-definition/connector-metadata.schema.json
@@ -1,99 +1,337 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "properties": {
-    "version": {
-      "const": "v1",
-      "type": "string"
-    },
-    "packagingDefinition": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "PrebuiltDockerImage"
-            },
-            "dockerImage": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "dockerImage",
-            "type"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "ManagedDockerBuild"
-            }
-          },
-          "required": [
-            "type"
-          ]
-        }
-      ]
-    },
-    "nativeToolchainDefinition": {
+  "anyOf": [
+    {
       "type": "object",
       "properties": {
+        "version": {
+          "const": "v1",
+          "type": "string"
+        },
+        "packagingDefinition": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "PrebuiltDockerImage"
+                },
+                "dockerImage": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dockerImage",
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "ManagedDockerBuild"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        },
+        "nativeToolchainDefinition": {
+          "type": "object",
+          "properties": {
+            "commands": {
+              "type": "object",
+              "properties": {
+                "start": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "Dockerized"
+                        },
+                        "dockerImage": {
+                          "type": "string"
+                        },
+                        "commandArgs": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "commandArgs",
+                        "dockerImage",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "ShellScript"
+                        },
+                        "bash": {
+                          "type": "string"
+                        },
+                        "powershell": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bash",
+                        "powershell",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "update": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "Dockerized"
+                        },
+                        "dockerImage": {
+                          "type": "string"
+                        },
+                        "commandArgs": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "commandArgs",
+                        "dockerImage",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "ShellScript"
+                        },
+                        "bash": {
+                          "type": "string"
+                        },
+                        "powershell": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bash",
+                        "powershell",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "watch": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "Dockerized"
+                        },
+                        "dockerImage": {
+                          "type": "string"
+                        },
+                        "commandArgs": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "commandArgs",
+                        "dockerImage",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "ShellScript"
+                        },
+                        "bash": {
+                          "type": "string"
+                        },
+                        "powershell": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bash",
+                        "powershell",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "upgradeConfiguration": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "Dockerized"
+                        },
+                        "dockerImage": {
+                          "type": "string"
+                        },
+                        "commandArgs": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "commandArgs",
+                        "dockerImage",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "ShellScript"
+                        },
+                        "bash": {
+                          "type": "string"
+                        },
+                        "powershell": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bash",
+                        "powershell",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "cliPluginEntrypoint": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "Dockerized"
+                        },
+                        "dockerImage": {
+                          "type": "string"
+                        },
+                        "commandArgs": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "commandArgs",
+                        "dockerImage",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "ShellScript"
+                        },
+                        "bash": {
+                          "type": "string"
+                        },
+                        "powershell": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bash",
+                        "powershell",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "start"
+              ]
+            }
+          },
+          "required": [
+            "commands"
+          ]
+        },
+        "supportedEnvironmentVariables": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "defaultValue": {
+                "type": "string"
+              },
+              "required": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "description",
+              "name"
+            ]
+          }
+        },
         "commands": {
           "type": "object",
           "properties": {
-            "start": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "const": "Dockerized"
-                    },
-                    "dockerImage": {
-                      "type": "string"
-                    },
-                    "commandArgs": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "required": [
-                    "commandArgs",
-                    "dockerImage",
-                    "type"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "const": "ShellScript"
-                    },
-                    "bash": {
-                      "type": "string"
-                    },
-                    "powershell": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "bash",
-                    "powershell",
-                    "type"
-                  ]
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
             "update": {
               "anyOf": [
                 {
@@ -194,6 +432,56 @@
                 }
               ]
             },
+            "printSchemaAndCapabilities": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "Dockerized"
+                    },
+                    "dockerImage": {
+                      "type": "string"
+                    },
+                    "commandArgs": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "commandArgs",
+                    "dockerImage",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "ShellScript"
+                    },
+                    "bash": {
+                      "type": "string"
+                    },
+                    "powershell": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "bash",
+                    "powershell",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
             "upgradeConfiguration": {
               "anyOf": [
                 {
@@ -243,8 +531,632 @@
                   "type": "string"
                 }
               ]
+            }
+          }
+        },
+        "cliPlugin": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "Docker"
+                },
+                "dockerImage": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dockerImage",
+                "type"
+              ]
             },
-            "cliPluginEntrypoint": {
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "BinaryInline"
+                },
+                "platforms": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "selector": {
+                        "description": "The selector identifies the target platform for this configuration.\nIt follows the format: <os>-<architecture>\n\nPossible values:\n- darwin-arm64: macOS on ARM64 architecture (e.g., M1 Macs)\n- linux-arm64: Linux on ARM64 architecture\n- darwin-amd64: macOS on x86-64 architecture\n- windows-amd64: Windows on x86-64 architecture\n- linux-amd64: Linux on x86-64 architecture",
+                        "enum": [
+                          "darwin-amd64",
+                          "darwin-arm64",
+                          "linux-amd64",
+                          "linux-arm64",
+                          "windows-amd64"
+                        ],
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The URI of the CLI plugin.\nThis CLI binary plugin should be a URL from where the binary can be downloaded,\nwithout any authentication.",
+                        "type": "string"
+                      },
+                      "sha256": {
+                        "description": "The SHA256 hash of the binary file. This is used to verify the integrity of the downloaded binary.",
+                        "type": "string"
+                      },
+                      "bin": {
+                        "description": "The name of the binary file. The binary file downloaded from the `uri` will be saved with this name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "bin",
+                      "selector",
+                      "sha256",
+                      "uri"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "platforms",
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "Binary",
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "version"
+              ]
+            }
+          ]
+        },
+        "dockerComposeWatch": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              },
+              "action": {
+                "enum": [
+                  "rebuild",
+                  "sync",
+                  "sync+restart"
+                ],
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              },
+              "ignore": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "action",
+              "path"
+            ]
+          }
+        },
+        "documentationPage": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "commands",
+        "dockerComposeWatch",
+        "packagingDefinition",
+        "supportedEnvironmentVariables"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "const": "v2"
+        },
+        "ndcSpecGeneration": {
+          "description": "Represents the version ranges (or \"generations\") of the NDC Specification.\n\nThis type refers to the value of DataConnectorLink.definition.schema.version,\nwhich indicates the generation of NDC Specification rather than a precise\nversion number (such as v0.1.6).",
+          "enum": [
+            "v0.1",
+            "v0.2"
+          ],
+          "type": "string"
+        },
+        "packagingDefinition": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "PrebuiltDockerImage"
+                },
+                "dockerImage": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dockerImage",
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "ManagedDockerBuild"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        },
+        "nativeToolchainDefinition": {
+          "type": "object",
+          "properties": {
+            "commands": {
+              "type": "object",
+              "properties": {
+                "start": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "Dockerized"
+                        },
+                        "dockerImage": {
+                          "type": "string"
+                        },
+                        "commandArgs": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "commandArgs",
+                        "dockerImage",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "ShellScript"
+                        },
+                        "bash": {
+                          "type": "string"
+                        },
+                        "powershell": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bash",
+                        "powershell",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "update": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "Dockerized"
+                        },
+                        "dockerImage": {
+                          "type": "string"
+                        },
+                        "commandArgs": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "commandArgs",
+                        "dockerImage",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "ShellScript"
+                        },
+                        "bash": {
+                          "type": "string"
+                        },
+                        "powershell": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bash",
+                        "powershell",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "watch": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "Dockerized"
+                        },
+                        "dockerImage": {
+                          "type": "string"
+                        },
+                        "commandArgs": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "commandArgs",
+                        "dockerImage",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "ShellScript"
+                        },
+                        "bash": {
+                          "type": "string"
+                        },
+                        "powershell": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bash",
+                        "powershell",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "upgradeConfiguration": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "Dockerized"
+                        },
+                        "dockerImage": {
+                          "type": "string"
+                        },
+                        "commandArgs": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "commandArgs",
+                        "dockerImage",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "ShellScript"
+                        },
+                        "bash": {
+                          "type": "string"
+                        },
+                        "powershell": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bash",
+                        "powershell",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "cliPluginEntrypoint": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "Dockerized"
+                        },
+                        "dockerImage": {
+                          "type": "string"
+                        },
+                        "commandArgs": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "commandArgs",
+                        "dockerImage",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "ShellScript"
+                        },
+                        "bash": {
+                          "type": "string"
+                        },
+                        "powershell": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "bash",
+                        "powershell",
+                        "type"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "start"
+              ]
+            }
+          },
+          "required": [
+            "commands"
+          ]
+        },
+        "supportedEnvironmentVariables": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "defaultValue": {
+                "type": "string"
+              },
+              "required": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "description",
+              "name"
+            ]
+          }
+        },
+        "commands": {
+          "type": "object",
+          "properties": {
+            "update": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "Dockerized"
+                    },
+                    "dockerImage": {
+                      "type": "string"
+                    },
+                    "commandArgs": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "commandArgs",
+                    "dockerImage",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "ShellScript"
+                    },
+                    "bash": {
+                      "type": "string"
+                    },
+                    "powershell": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "bash",
+                    "powershell",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "watch": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "Dockerized"
+                    },
+                    "dockerImage": {
+                      "type": "string"
+                    },
+                    "commandArgs": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "commandArgs",
+                    "dockerImage",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "ShellScript"
+                    },
+                    "bash": {
+                      "type": "string"
+                    },
+                    "powershell": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "bash",
+                    "powershell",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "printSchemaAndCapabilities": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "Dockerized"
+                    },
+                    "dockerImage": {
+                      "type": "string"
+                    },
+                    "commandArgs": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "commandArgs",
+                    "dockerImage",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "ShellScript"
+                    },
+                    "bash": {
+                      "type": "string"
+                    },
+                    "powershell": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "bash",
+                    "powershell",
+                    "type"
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "upgradeConfiguration": {
               "anyOf": [
                 {
                   "type": "object",
@@ -294,374 +1206,123 @@
                 }
               ]
             }
-          },
-          "required": [
-            "start"
+          }
+        },
+        "cliPlugin": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "Docker"
+                },
+                "dockerImage": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dockerImage",
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "BinaryInline"
+                },
+                "platforms": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "selector": {
+                        "description": "The selector identifies the target platform for this configuration.\nIt follows the format: <os>-<architecture>\n\nPossible values:\n- darwin-arm64: macOS on ARM64 architecture (e.g., M1 Macs)\n- linux-arm64: Linux on ARM64 architecture\n- darwin-amd64: macOS on x86-64 architecture\n- windows-amd64: Windows on x86-64 architecture\n- linux-amd64: Linux on x86-64 architecture",
+                        "enum": [
+                          "darwin-amd64",
+                          "darwin-arm64",
+                          "linux-amd64",
+                          "linux-arm64",
+                          "windows-amd64"
+                        ],
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The URI of the CLI plugin.\nThis CLI binary plugin should be a URL from where the binary can be downloaded,\nwithout any authentication.",
+                        "type": "string"
+                      },
+                      "sha256": {
+                        "description": "The SHA256 hash of the binary file. This is used to verify the integrity of the downloaded binary.",
+                        "type": "string"
+                      },
+                      "bin": {
+                        "description": "The name of the binary file. The binary file downloaded from the `uri` will be saved with this name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "bin",
+                      "selector",
+                      "sha256",
+                      "uri"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "platforms",
+                "type"
+              ]
+            }
           ]
+        },
+        "dockerComposeWatch": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              },
+              "action": {
+                "enum": [
+                  "rebuild",
+                  "sync",
+                  "sync+restart"
+                ],
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              },
+              "ignore": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "action",
+              "path"
+            ]
+          }
+        },
+        "documentationPage": {
+          "type": "string"
         }
       },
       "required": [
-        "commands"
+        "commands",
+        "dockerComposeWatch",
+        "ndcSpecGeneration",
+        "packagingDefinition",
+        "supportedEnvironmentVariables",
+        "version"
       ]
-    },
-    "supportedEnvironmentVariables": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "defaultValue": {
-            "type": "string"
-          },
-          "required": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "description",
-          "name"
-        ]
-      }
-    },
-    "commands": {
-      "type": "object",
-      "properties": {
-        "update": {
-          "anyOf": [
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "const": "Dockerized"
-                },
-                "dockerImage": {
-                  "type": "string"
-                },
-                "commandArgs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "commandArgs",
-                "dockerImage",
-                "type"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "const": "ShellScript"
-                },
-                "bash": {
-                  "type": "string"
-                },
-                "powershell": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "bash",
-                "powershell",
-                "type"
-              ]
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "watch": {
-          "anyOf": [
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "const": "Dockerized"
-                },
-                "dockerImage": {
-                  "type": "string"
-                },
-                "commandArgs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "commandArgs",
-                "dockerImage",
-                "type"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "const": "ShellScript"
-                },
-                "bash": {
-                  "type": "string"
-                },
-                "powershell": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "bash",
-                "powershell",
-                "type"
-              ]
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "printSchemaAndCapabilities": {
-          "anyOf": [
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "const": "Dockerized"
-                },
-                "dockerImage": {
-                  "type": "string"
-                },
-                "commandArgs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "commandArgs",
-                "dockerImage",
-                "type"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "const": "ShellScript"
-                },
-                "bash": {
-                  "type": "string"
-                },
-                "powershell": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "bash",
-                "powershell",
-                "type"
-              ]
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "upgradeConfiguration": {
-          "anyOf": [
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "const": "Dockerized"
-                },
-                "dockerImage": {
-                  "type": "string"
-                },
-                "commandArgs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "commandArgs",
-                "dockerImage",
-                "type"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "const": "ShellScript"
-                },
-                "bash": {
-                  "type": "string"
-                },
-                "powershell": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "bash",
-                "powershell",
-                "type"
-              ]
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
-      }
-    },
-    "cliPlugin": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "Binary",
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "version": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "version"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "BinaryInline"
-            },
-            "platforms": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "selector": {
-                    "description": "The selector identifies the target platform for this configuration.\nIt follows the format: <os>-<architecture>\n\nPossible values:\n- darwin-arm64: macOS on ARM64 architecture (e.g., M1 Macs)\n- linux-arm64: Linux on ARM64 architecture\n- darwin-amd64: macOS on x86-64 architecture\n- windows-amd64: Windows on x86-64 architecture\n- linux-amd64: Linux on x86-64 architecture",
-                    "enum": [
-                      "darwin-amd64",
-                      "darwin-arm64",
-                      "linux-amd64",
-                      "linux-arm64",
-                      "windows-amd64"
-                    ],
-                    "type": "string"
-                  },
-                  "uri": {
-                    "description": "The URI of the CLI plugin.\nThis CLI binary plugin should be a URL from where the binary can be downloaded,\nwithout any authentication.",
-                    "type": "string"
-                  },
-                  "sha256": {
-                    "description": "The SHA256 hash of the binary file. This is used to verify the integrity of the downloaded binary.",
-                    "type": "string"
-                  },
-                  "bin": {
-                    "description": "The name of the binary file. The binary file downloaded from the `uri` will be saved with this name.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "bin",
-                  "selector",
-                  "sha256",
-                  "uri"
-                ]
-              }
-            }
-          },
-          "required": [
-            "platforms",
-            "type"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "Docker"
-            },
-            "dockerImage": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "dockerImage",
-            "type"
-          ]
-        }
-      ]
-    },
-    "dockerComposeWatch": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string"
-          },
-          "action": {
-            "enum": [
-              "rebuild",
-              "sync",
-              "sync+restart"
-            ],
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          },
-          "ignore": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "action",
-          "path"
-        ]
-      }
-    },
-    "documentationPage": {
-      "type": "string"
     }
-  },
-  "required": [
-    "commands",
-    "dockerComposeWatch",
-    "packagingDefinition",
-    "supportedEnvironmentVariables"
-  ]
+  ],
+  "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/connector-definition/connector-metadata.yaml
+++ b/connector-definition/connector-metadata.yaml
@@ -1,4 +1,6 @@
 # yaml-language-server: $schema=connector-metadata.schema.json
+version: v2
+ndcSpecGeneration: v0.2
 packagingDefinition:
   type: ManagedDockerBuild
 nativeToolchainDefinition:

--- a/ndc-lambda-sdk/package-lock.json
+++ b/ndc-lambda-sdk/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-lambda-sdk",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hasura/ndc-sdk-typescript": "^7.1.0",
+        "@hasura/ndc-sdk-typescript": "^8.2.0",
         "@hasura/ts-node-dev": "^2.1.0",
         "@tsconfig/node20": "^20.1.4",
         "commander": "^11.1.0",
@@ -44,6 +44,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz",
+      "integrity": "sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.5.0.tgz",
@@ -52,6 +60,21 @@
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "fast-uri": "^2.0.0"
+      }
+    },
+    "node_modules/@fastify/compress": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/compress/-/compress-7.0.3.tgz",
+      "integrity": "sha512-xa9fo5/DgK1s0bkS6xrYgNn8HmofO5tJvbCDk8QuXshSgLd2cFZANv1ox/Qv7zswS7JroHwTlCVv/XGTVO98tg==",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^1.1.0",
+        "fastify-plugin": "^4.5.0",
+        "mime-db": "^1.52.0",
+        "minipass": "^7.0.2",
+        "peek-stream": "^1.1.3",
+        "pump": "^3.0.0",
+        "pumpify": "^2.0.1",
+        "readable-stream": "^4.5.2"
       }
     },
     "node_modules/@fastify/deepmerge": {
@@ -140,10 +163,11 @@
       }
     },
     "node_modules/@hasura/ndc-sdk-typescript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-7.1.0.tgz",
-      "integrity": "sha512-oHlGM+AdSPDwpJLiTejmMwtu/NRFjCTFJ+uBC3F2wzQCAOQ5zlXZYBJqhrj4eQ0KMKoxCI8znKrH23H63UcHLQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@hasura/ndc-sdk-typescript/-/ndc-sdk-typescript-8.2.0.tgz",
+      "integrity": "sha512-Y1jdhBvqhFoc3CcUAGPPX2LuEiviYxwnR+ieX2QPvLcoTmbR6l60QGlbq30BWxYbs7YQ1iZ+qkLbFzi7Fd6cqg==",
       "dependencies": {
+        "@fastify/compress": "^7.0.3",
         "@json-schema-tools/meta-schema": "^1.7.0",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/exporter-metrics-otlp-grpc": "^0.53.0",
@@ -159,7 +183,8 @@
         "commander": "^11.0.0",
         "fastify": "^4.23.2",
         "pino-pretty": "^10.2.3",
-        "prom-client": "^15.1.2"
+        "prom-client": "^15.1.2",
+        "semver": "^7.6.3"
       }
     },
     "node_modules/@hasura/ts-node-dev": {
@@ -1990,9 +2015,9 @@
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2212,6 +2237,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2284,6 +2314,44 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/dynamic-dedupe": {
@@ -2446,6 +2514,11 @@
         "semver": "^7.5.4",
         "toad-cache": "^3.3.0"
       }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
+      "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ=="
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -2680,8 +2753,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -2768,6 +2840,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2889,21 +2966,18 @@
         "get-func-name": "^2.0.1"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/minimatch": {
       "version": "5.1.6",
@@ -3132,6 +3206,16 @@
         "node": "*"
       }
     },
+    "node_modules/peek-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3234,6 +3318,11 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/process-warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
@@ -3295,6 +3384,40 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      }
+    },
+    "node_modules/pumpify/node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/pumpify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3318,9 +3441,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.1.tgz",
-      "integrity": "sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -3459,12 +3582,9 @@
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3565,6 +3685,11 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -3680,6 +3805,42 @@
       "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
       "dependencies": {
         "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3816,6 +3977,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -3894,11 +4060,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/ndc-lambda-sdk/package.json
+++ b/ndc-lambda-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-lambda-sdk",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "SDK that can automatically expose TypeScript functions as Hasura NDC functions/procedures",
   "author": "Hasura",
   "license": "Apache-2.0",
@@ -31,7 +31,7 @@
     "url": "git+https://github.com/hasura/ndc-nodejs-lambda.git"
   },
   "dependencies": {
-    "@hasura/ndc-sdk-typescript": "^7.1.0",
+    "@hasura/ndc-sdk-typescript": "^8.2.0",
     "@hasura/ts-node-dev": "^2.1.0",
     "@tsconfig/node20": "^20.1.4",
     "commander": "^11.1.0",

--- a/ndc-lambda-sdk/src/execution.ts
+++ b/ndc-lambda-sdk/src/execution.ts
@@ -288,6 +288,7 @@ export function reshapeResultUsingFieldSelection(value: unknown, type: schema.Ty
           case "scalar": return fieldSelection;
           case "array": return fieldSelection.fields;
           case "object": throw new sdk.BadRequest(`Trying to perform an object selection on an array type at '${valuePath.join(".")}'`)
+          case "collection": throw new sdk.NotSupported(`Trying to perform an unsupported collection nested field selection at '${valuePath.join(".")}'`)
           default: return unreachable(fieldSelection["type"]);
         }
       })();
@@ -321,6 +322,7 @@ export function reshapeResultUsingFieldSelection(value: unknown, type: schema.Ty
               case "scalar": return Object.fromEntries(objectType.properties.map(propDef => [propDef.propertyName, { type: "column", column: propDef.propertyName }]));
               case "array": throw new sdk.BadRequest(`Trying to perform an array selection on an object type at '${valuePath.join(".")}'`);
               case "object": return fieldSelection.fields;
+              case "collection": throw new sdk.NotSupported(`Trying to perform an unsupported collection nested field selection at '${valuePath.join(".")}'`)
               default: return unreachable(fieldSelection["type"]);
             }
           })();

--- a/ndc-lambda-sdk/src/host.ts
+++ b/ndc-lambda-sdk/src/host.ts
@@ -1,6 +1,7 @@
 // We must initialize OpenTelemetry instrumentation before importing any other module
 import * as sdkInstrumentation from "@hasura/ndc-sdk-typescript/instrumentation";
-sdkInstrumentation.initTelemetry("ndc-lambda-sdk");
+import { version as packageVersion } from "../package.json";
+sdkInstrumentation.initTelemetry("ndc-lambda-sdk", undefined, undefined, "ndc-nodejs-lambda", packageVersion);
 
 import * as sdk from "@hasura/ndc-sdk-typescript";
 import { createConnector } from "./connector";

--- a/ndc-lambda-sdk/src/schema.ts
+++ b/ndc-lambda-sdk/src/schema.ts
@@ -238,7 +238,8 @@ export function getNdcSchema(functionsSchema: FunctionsSchema): sdk.SchemaRespon
         }
         return [propDef.propertyName, objField];
       })),
-      ...(objDef.description ? { description: objDef.description } : {})
+      foreign_keys: {},
+      ...(objDef.description ? { description: objDef.description } : {}),
     }
   });
 
@@ -250,6 +251,7 @@ export function getNdcSchema(functionsSchema: FunctionsSchema): sdk.SchemaRespon
           : throwError(`built-in scalar type with unexpected name: ${scalarTypeName}`);
       case "relaxed-type":
         return {
+          representation: { type: "json" },
           aggregate_functions: {},
           comparison_operators: {},
         };

--- a/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
+++ b/ndc-lambda-sdk/test/schema/ndc-schema.test.ts
@@ -201,6 +201,7 @@ describe("ndc schema", function() {
               },
             },
           },
+          foreign_keys: {}
         },
       },
       scalar_types: {
@@ -245,6 +246,7 @@ describe("ndc schema", function() {
           comparison_operators: {}
         },
         "MyRelaxedType": {
+          representation: { type: "json" },
           aggregate_functions: {},
           comparison_operators: {}
         },


### PR DESCRIPTION
Updates the NDC TypeScript SDK to v8.2.0, which means this connector starts talking NDC Spec 0.2.0. Some minor changes were made to support this.

Tracing now also includes the connector name and version in the span attributes.

Completes ENG-1833