### PR TITLE
non root user

### DIFF
--- a/connector-definition/Dockerfile
+++ b/connector-definition/Dockerfile
@@ -7,3 +7,5 @@ RUN --mount=type=cache,target=/home/hasura/.npm,uid=1001,gid=1001 \
     npm ci
 
 COPY --chown=hasura:hasura ./ /functions
+
+USER hasura:hasura


### PR DESCRIPTION
This is to resolve trivy scan report

```
.hasura-connector/Dockerfile (dockerfile)                                                                                       
  =========================================                                                                                       
  Tests: 20 (SUCCESSES: 19, FAILURES: 1)                                                                                          
  Failures: 1 (HIGH: 1, CRITICAL: 0)                                                                                              
                                                                                                                                  
  DS-0002 (HIGH): Specify at least 1 USER command in Dockerfile with non-root user as argument                                    
  ════════════════════════════════════════                                                                                        
  Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as        
  non-root users, which can be done by adding a 'USER' statement to the Dockerfile.                                               
```

This has been tested locally for introspection, cloud build, and local build.