### PR TITLE
Add .trivyignore for npm-bundled CVEs pending upstream fix

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# CVE-2026-27903: minimatch - DoS via unbounded recursive backtracking in glob patterns
+# CVE-2026-27904: minimatch - DoS via catastrophic backtracking in glob expressions
+# CVE-2026-29786: tar - Hardlink path traversal via drive-relative linkpath
+#
+# These vulnerabilities exist in packages bundled within npm itself (not in our application
+# dependencies). They cannot be resolved by updating our own package.json — a fix requires
+# a new npm release that ships patched versions of minimatch and tar internally.
+#
+# TODO: Remove these ignores once a fixed version of npm is available and deployed in the
+# base image. Track the npm release notes for minimatch >= <fixed-version> and tar >= <fixed-version>.
+CVE-2026-27903
+CVE-2026-27904
+CVE-2026-29786


### PR DESCRIPTION
## Summary

Trivy image scans are flagging three CVEs that exist inside npm's own bundled dependencies, not in our application code. Because they live within npm itself, we cannot resolve them by updating our `package.json` — a fix requires a new npm release that ships patched internal versions of `minimatch` and `tar`.

This PR adds a `.trivyignore` to suppress these findings until that upstream fix is available.

### Suppressed CVEs

| CVE | Package | Description |
|-----|---------|-------------|
| CVE-2026-27903 | `minimatch` (bundled in npm) | Denial of Service via unbounded recursive backtracking in crafted glob patterns |
| CVE-2026-27904 | `minimatch` (bundled in npm) | Denial of Service via catastrophic backtracking in glob expressions |
| CVE-2026-29786 | `tar` (bundled in npm) | Hardlink path traversal via drive-relative link path |

### Why we can't fix these now

These packages are shipped as internal dependencies of npm itself (under `/usr/lib/node_modules/npm/node_modules/`). Upgrading them requires npm to cut a new release with patched versions. There is no action we can take in this repository to resolve them sooner.

### Follow-up

Once a fixed npm version is available and deployed in the base image, the ignore entries should be removed. See the TODO comment in `.trivyignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)