### PR TITLE
ci: disable trivy vulnerability scanning

### DIFF
--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -128,40 +128,40 @@ jobs:
           load: true
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
 
-      - name: Run Trivy vulnerability scanner (json output)
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
-          format: json
-          output: trivy-results.json
-          scanners: vuln
-
-      - name: Upload Trivy scan results to Security Agent
-        if: always()
-        uses: hasura/security-agent-tools/upload-file@v1
-        with:
-          file_path: trivy-results.json
-          security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
-          tags: |
-            service=ndc-nodejs-lambda
-            source_code_path=.
-            docker_file_path=Dockerfile
-            scanner=trivy
-            image_name=${{ steps.docker-metadata.outputs.tags }}
-            product_domain=hasura-ddn-data-plane
-            team=engine
-
-      - name: Fail build on High/Critical Vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          skip-setup-trivy: true
-          image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
-          format: table
-          severity: CRITICAL,HIGH
-          scanners: vuln
-          ignore-unfixed: true
-          exit-code: 1
-
+#       - name: Run Trivy vulnerability scanner (json output)
+#         uses: aquasecurity/trivy-action@v0.35.0
+#         with:
+#           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
+#           format: json
+#           output: trivy-results.json
+#           scanners: vuln
+# 
+#       - name: Upload Trivy scan results to Security Agent
+#         if: always()
+#         uses: hasura/security-agent-tools/upload-file@v1
+#         with:
+#           file_path: trivy-results.json
+#           security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
+#           tags: |
+#             service=ndc-nodejs-lambda
+#             source_code_path=.
+#             docker_file_path=Dockerfile
+#             scanner=trivy
+#             image_name=${{ steps.docker-metadata.outputs.tags }}
+#             product_domain=hasura-ddn-data-plane
+#             team=engine
+# 
+#       - name: Fail build on High/Critical Vulnerabilities
+#         uses: aquasecurity/trivy-action@v0.35.0
+#         with:
+#           skip-setup-trivy: true
+#           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
+#           format: table
+#           severity: CRITICAL,HIGH
+#           scanners: vuln
+#           ignore-unfixed: true
+#           exit-code: 1
+# 
       - name: Push docker image
         uses: docker/build-push-action@v6
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
## Summary
- Disable Trivy vulnerability scanning steps/jobs in CI pipelines
- Trivy scan steps have been commented out from workflow/pipeline files

## Test plan
- [ ] Verify CI pipelines still run successfully without trivy steps
- [ ] Confirm no downstream jobs depend on the disabled scan steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)