### PR TITLE
ci: re-enable trivy vulnerability scanning with SHA-pinned action

### DIFF
--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -129,7 +129,7 @@ jobs:
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
 
       - name: Run Trivy vulnerability scanner (json output)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
           format: json
@@ -152,7 +152,7 @@ jobs:
             team=engine
 
       - name: Fail build on High/Critical Vulnerabilities
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           skip-setup-trivy: true
           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan

--- a/.github/workflows/ndc-nodejs-lambda-connector.yaml
+++ b/.github/workflows/ndc-nodejs-lambda-connector.yaml
@@ -128,40 +128,40 @@ jobs:
           load: true
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
 
-#       - name: Run Trivy vulnerability scanner (json output)
-#         uses: aquasecurity/trivy-action@v0.35.0
-#         with:
-#           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
-#           format: json
-#           output: trivy-results.json
-#           scanners: vuln
-# 
-#       - name: Upload Trivy scan results to Security Agent
-#         if: always()
-#         uses: hasura/security-agent-tools/upload-file@v1
-#         with:
-#           file_path: trivy-results.json
-#           security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
-#           tags: |
-#             service=ndc-nodejs-lambda
-#             source_code_path=.
-#             docker_file_path=Dockerfile
-#             scanner=trivy
-#             image_name=${{ steps.docker-metadata.outputs.tags }}
-#             product_domain=hasura-ddn-data-plane
-#             team=engine
-# 
-#       - name: Fail build on High/Critical Vulnerabilities
-#         uses: aquasecurity/trivy-action@v0.35.0
-#         with:
-#           skip-setup-trivy: true
-#           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
-#           format: table
-#           severity: CRITICAL,HIGH
-#           scanners: vuln
-#           ignore-unfixed: true
-#           exit-code: 1
-# 
+      - name: Run Trivy vulnerability scanner (json output)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        with:
+          image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
+          format: json
+          output: trivy-results.json
+          scanners: vuln
+
+      - name: Upload Trivy scan results to Security Agent
+        if: always()
+        uses: hasura/security-agent-tools/upload-file@v1
+        with:
+          file_path: trivy-results.json
+          security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
+          tags: |
+            service=ndc-nodejs-lambda
+            source_code_path=.
+            docker_file_path=Dockerfile
+            scanner=trivy
+            image_name=${{ steps.docker-metadata.outputs.tags }}
+            product_domain=hasura-ddn-data-plane
+            team=engine
+
+      - name: Fail build on High/Critical Vulnerabilities
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        with:
+          skip-setup-trivy: true
+          image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:scan
+          format: table
+          severity: CRITICAL,HIGH
+          scanners: vuln
+          ignore-unfixed: true
+          exit-code: 1
+
       - name: Push docker image
         uses: docker/build-push-action@v6
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Re-enable Trivy scanning by reverting the changes from PR #78. Pin trivy-action to `ed142fd0673e97e23eac54620cfb913e5ce36c25` (v0.36.0) for security.

Co-authored-by: Poojan Savani <poojan@hasura.io>